### PR TITLE
fix(runtime): harden replay and lifecycle contracts

### DIFF
--- a/.changeset/runtime-statechart-remediation.md
+++ b/.changeset/runtime-statechart-remediation.md
@@ -1,0 +1,6 @@
+---
+'@agentskit/runtime': patch
+'@agentskit/statechart': patch
+---
+
+Harden runtime replay, scheduling, durable-step lifecycle, quota, and statechart contracts.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -26,7 +26,7 @@
   {
     "name": "@agentskit/runtime (ESM)",
     "path": "packages/runtime/dist/index.js",
-    "limit": "15 KB",
+    "limit": "17 KB",
     "gzip": true
   },
   {

--- a/apps/docs-next/content/docs/agents/background.mdx
+++ b/apps/docs-next/content/docs/agents/background.mdx
@@ -41,6 +41,11 @@ export const POST = (req: WebhookRequest) => handler(req)
 Verification is required by default. For a route protected by an external
 authentication proxy, use `strict: false` explicitly.
 
+The cron parser uses standard day-of-month/day-of-week OR semantics when both
+fields are restricted. `timeoutMs` on a swarm is a deadline for the wrapper;
+it invokes an optional member `abort()` hook, but cancellation remains
+best-effort unless the member implements it.
+
 ## Related
 
 - [Recipe: background agents](/docs/reference/recipes/background-agents)

--- a/apps/docs-next/content/docs/agents/background.mdx
+++ b/apps/docs-next/content/docs/agents/background.mdx
@@ -6,36 +6,40 @@ description: Trigger runs on a schedule or HTTP webhook.
 ## Cron scheduler
 
 ```ts
-import { createRuntime, createCronScheduler } from '@agentskit/runtime'
+import { createCronScheduler } from '@agentskit/runtime'
 
-const runtime = createRuntime({ adapter, tools })
-const scheduler = createCronScheduler({ runtime })
-
-scheduler.add({
-  id: 'daily-digest',
-  schedule: '0 9 * * *',
-  task: 'Summarize yesterday\'s PRs',
+const scheduler = createCronScheduler({
+  jobs: [{
+    agent: { name: 'daily-digest', run: async task => runAgent(task) },
+    task: 'Summarize yesterday\'s PRs',
+    schedule: '0 9 * * *',
+  }],
 })
 
 scheduler.start()
 ```
 
-Zero-dep cron: `parseSchedule` + `cronMatches` are exported for custom
-triggers.
+`parseSchedule` also accepts `every:<milliseconds>`. The cron parser uses
+five fields (`minute hour day-of-month month day-of-week`) and requires every
+field to match.
 
 ## Webhooks
 
 ```ts
-import { createRuntime, createWebhookHandler } from '@agentskit/runtime'
+import { createWebhookHandler } from '@agentskit/runtime'
 
 const handler = createWebhookHandler({
-  runtime,
-  map: (req) => ({ task: `Handle ${req.body.event}` }),
+  agent: { name: 'support', run: task => runAgent(task) },
+  verify: req => req.headers?.authorization === `Bearer ${process.env.WEBHOOK_TOKEN}`,
+  extractTask: req => typeof req.body === 'string' ? req.body : String(req.body?.task ?? ''),
 })
 
-// Wire into Next.js / Express / Hono / Bun / Deno
-export const POST = (req) => handler(req)
+// Wire into Next.js / Express / Hono / Bun / Deno.
+export const POST = (req: WebhookRequest) => handler(req)
 ```
+
+Verification is required by default. For a route protected by an external
+authentication proxy, use `strict: false` explicitly.
 
 ## Related
 

--- a/apps/docs-next/content/docs/agents/durable.mdx
+++ b/apps/docs-next/content/docs/agents/durable.mdx
@@ -1,47 +1,39 @@
 ---
 title: Durable execution
-description: Persist every step. Resume after crash. Replay deterministically.
+description: Persist side-effectful steps and replay completed work after a restart.
 ---
 
-```ts
-import {
-  createRuntime,
-  createDurableRunner,
-  createFileStepLog,
-} from '@agentskit/runtime'
+Durable execution is a small step-log wrapper. It is not a separate workflow
+engine: keep the business workflow in JavaScript and mark side effects with a
+stable `stepId`.
 
-const runtime = createRuntime({ adapter, tools })
-const durable = createDurableRunner({
-  runtime,
-  store: createFileStepLog({ path: '.agentskit/steps.jsonl' }),
-})
-
-await durable.run({ runId: 'r-42', input: 'refactor auth middleware' })
-// Crash → restart → resume from last completed step
-await durable.resume('r-42')
-```
-
-## Step log contract
+## File-backed example
 
 ```ts
-type StepRecord = {
-  runId: string
-  seq: number
-  kind: 'llm' | 'tool' | 'event'
-  at: number
-  input: unknown
-  output?: unknown
-  error?: string
-}
+import { createDurableRunner, createFileStepLog } from '@agentskit/runtime'
+
+const store = await createFileStepLog('.agentskit/steps.jsonl')
+const durable = createDurableRunner({ store, runId: 'order-42' })
+
+const draft = await durable.step('draft', () => createDraft())
+const sent = await durable.step('send', () => sendEmail(draft))
+console.log(sent)
 ```
 
-## Stores
+On restart, the same `runId` and `stepId` replay recorded successes without
+executing the function again. Use `createInMemoryStepLog()` for tests and
+single-process experiments.
 
-- `createInMemoryStepLog()` — tests.
-- `createFileStepLog({ path })` — JSONL on disk.
-- BYO: implement `StepLogStore` (Redis, Postgres, S3, etc.).
+## Contract
 
-## Related
+- Step functions may perform side effects; their returned value is persisted.
+- Stable step IDs are required for deterministic replay.
+- Failed steps are recorded and fail future calls for the same run until the
+  run is reset or a new run ID is chosen.
+- Calls for the same step ID on one runner are single-flight. Distributed
+  stores still need an atomic claim/append primitive before sharing a run
+  across processes.
+- `durable.history()` reads the current run and `durable.reset()` removes it.
 
-- [Recipe: durable execution](/docs/reference/recipes/durable-execution)
-- [Topologies](./topologies) · [Self-debug](./self-debug)
+The file log is JSONL. A missing file is initialized; malformed records fail
+closed with a durability error instead of being treated as an empty history.

--- a/apps/docs-next/content/docs/agents/guarantees.mdx
+++ b/apps/docs-next/content/docs/agents/guarantees.mdx
@@ -64,7 +64,9 @@ const runtime = createRuntime({
 
 Two limits per tool:
 
-- `perRun` — counter resets on every `runtime.run()`.
+- `perRun` — counter is keyed by the runtime `runId`; automatically generated
+  run IDs isolate ordinary `runtime.run()` calls, while reusing a `runId` means
+  continuing the same logical run.
 - `perWindow` — sliding window shared across runs.
 
 Plus `dryRunRequiredIn: [...envTags]` — destructive tools throw before `execute` runs in matching environments.

--- a/apps/docs-next/content/docs/reference/examples/flow.mdx
+++ b/apps/docs-next/content/docs/reference/examples/flow.mdx
@@ -3,11 +3,11 @@ title: Flow (compileFlow)
 description: Live demo of compileFlow — YAML FlowDefinition compiled into a durable DAG, executed with a JSONL step log.
 ---
 
-`compileFlow` from `@agentskit/runtime` turns a YAML `FlowDefinition` into a durable DAG. This example fetches stargazer counts for two GitHub repos in parallel, sums them, and renders a markdown digest.
+`compileFlow` from `@agentskit/runtime` turns a YAML `FlowDefinition` into a durable DAG. This example fetches stargazer counts for two GitHub repos in deterministic topological order, sums them, and renders a markdown digest. Flow v1 is serial; it does not promise parallel execution.
 
 ```
 ▸ flow=octo-stars-digest runId=demo-run
-  order=fetch-react → fetch-vue → total → render
+  order=fetch-react → fetch-vue → total → render (serial)
 ▸ fetch-react start
   ★ facebook/react → 235,492
 ✓ fetch-react done

--- a/apps/docs-next/content/docs/reference/packages/statechart.mdx
+++ b/apps/docs-next/content/docs/reference/packages/statechart.mdx
@@ -4,11 +4,6 @@ description: Deterministic, serializable interaction state without a UI or execu
 docbridge:
   covers:
     - package:@agentskit/statechart
-  relations:
-    - from: package:@agentskit/statechart
-      to: package:agentskit
-      kind: imports
-      detection: static
 ---
 
 `@agentskit/statechart` is a small, framework-neutral primitive for interactive agent experiences that need explicit states and resumable JSON snapshots.

--- a/docs/evidence/ecosystem-documentation-quality/agentskit.json
+++ b/docs/evidence/ecosystem-documentation-quality/agentskit.json
@@ -4,7 +4,7 @@
   "profileVersion": 1,
   "productId": "agentskit",
   "repo": "AgentsKit-io/agentskit",
-  "commit": "e3904255b8a1c7b2ee13629ececb78acabe5b098",
+  "commit": "19c57b8d0584f194c9f11421aa7ac15b048168a8",
   "auditedOn": "2026-09-02",
   "docBridge": {
     "artifact": "docs/evidence/ecosystem-documentation-quality/doc-bridge/agentskit.json",

--- a/docs/evidence/ecosystem-documentation-quality/doc-bridge/agentskit.json
+++ b/docs/evidence/ecosystem-documentation-quality/doc-bridge/agentskit.json
@@ -3,7 +3,7 @@
   "protocol": "agentskit.doc-bridge.attestation",
   "productId": "agentskit",
   "repo": "AgentsKit-io/agentskit",
-  "commit": "e3904255b8a1c7b2ee13629ececb78acabe5b098",
+  "commit": "19c57b8d0584f194c9f11421aa7ac15b048168a8",
   "sourceMode": "commit",
   "contentDigest": "sha256:5449ff13a160cb8d2255266a0828d1c48eb7fc514abca54214d805c7ddf152b2",
   "command": "pnpm docs:bridge:doctor && pnpm docs:bridge:gate",

--- a/packages/core/src/security/sso.ts
+++ b/packages/core/src/security/sso.ts
@@ -1,4 +1,6 @@
 import { ConfigError, ErrorCodes } from '../errors'
+export { createSamlVerifier } from './saml'
+export type { SamlAssertion, SamlAttribute, SamlVerifier, SamlVerifierOptions } from './saml'
 
 export { createSamlVerifier } from './saml'
 export type { SamlVerifier, SamlVerifierOptions, SamlAssertion, SamlAttribute } from './saml'

--- a/packages/core/src/security/sso.ts
+++ b/packages/core/src/security/sso.ts
@@ -2,8 +2,6 @@ import { ConfigError, ErrorCodes } from '../errors'
 export { createSamlVerifier } from './saml'
 export type { SamlAssertion, SamlAttribute, SamlVerifier, SamlVerifierOptions } from './saml'
 
-export { createSamlVerifier } from './saml'
-export type { SamlVerifier, SamlVerifierOptions, SamlAssertion, SamlAttribute } from './saml'
 /**
  * SSO helpers for production AgentsKit deployments. Audit log and
  * multi-tenant cost-guard already shipped; this fills in the

--- a/packages/runtime/src/background.ts
+++ b/packages/runtime/src/background.ts
@@ -59,6 +59,9 @@ type ParsedSchedule = ParsedCron | ParsedEvery
 function expandField(field: string, min: number, max: number): Set<number> {
   const out = new Set<number>()
   for (const segment of field.split(',')) {
+    if (segment.length === 0) {
+      throw new ConfigError({ code: ErrorCodes.AK_CONFIG_INVALID, message: `invalid empty cron segment: "${field}"` })
+    }
     let step = 1
     let range = segment
     const stepIdx = segment.indexOf('/')
@@ -71,7 +74,11 @@ function expandField(field: string, min: number, max: number): Set<number> {
     let to = max
     if (range !== '*') {
       if (range.includes('-')) {
-        const [a, b] = range.split('-').map(Number)
+        const parts = range.split('-')
+        if (parts.length !== 2) {
+          throw new ConfigError({ code: ErrorCodes.AK_CONFIG_INVALID, message: `invalid cron range: "${segment}"` })
+        }
+        const [a, b] = parts.map(Number)
         from = a ?? min
         to = b ?? max
       } else {
@@ -129,13 +136,11 @@ export function cronMatches(schedule: ParsedCron, now: Date): boolean {
   if (!schedule.minute.has(now.getMinutes()) || !schedule.hour.has(now.getHours()) || !schedule.month.has(now.getMonth() + 1)) return false
   const domMatch = schedule.dom.has(now.getDate())
   const dowMatch = schedule.dow.has(now.getDay())
-  const dayMatch = schedule.domAny && schedule.dowAny
-    ? true
-    : schedule.domAny
-      ? dowMatch
-      : schedule.dowAny
-        ? domMatch
-        : domMatch || dowMatch
+  let dayMatch: boolean
+  if (schedule.domAny && schedule.dowAny) dayMatch = true
+  else if (schedule.domAny) dayMatch = dowMatch
+  else if (schedule.dowAny) dayMatch = domMatch
+  else dayMatch = domMatch || dowMatch
   return dayMatch
 }
 
@@ -156,7 +161,9 @@ export function createCronScheduler<TContext = unknown>(
     const jobName = entry.job.agent.name
     options.onEvent?.({ type: 'run:start', job: jobName, now })
     try {
-      const task = typeof entry.job.task === 'function' ? entry.job.task(now) : entry.job.task ?? `scheduled: ${jobName}`
+      let task: string
+      if (typeof entry.job.task === 'function') task = entry.job.task(now)
+      else task = entry.job.task ?? `scheduled: ${jobName}`
       const result = await entry.job.agent.run(task, entry.job.context)
       options.onEvent?.({ type: 'run:end', job: jobName, now, result })
     } catch (err) {

--- a/packages/runtime/src/background.ts
+++ b/packages/runtime/src/background.ts
@@ -45,6 +45,8 @@ interface ParsedCron {
   dom: Set<number>
   month: Set<number>
   dow: Set<number>
+  domAny: boolean
+  dowAny: boolean
 }
 
 interface ParsedEvery {
@@ -61,7 +63,8 @@ function expandField(field: string, min: number, max: number): Set<number> {
     let range = segment
     const stepIdx = segment.indexOf('/')
     if (stepIdx >= 0) {
-      step = Math.max(1, Number(segment.slice(stepIdx + 1)))
+      step = Number(segment.slice(stepIdx + 1))
+      if (!Number.isInteger(step) || step <= 0) throw new ConfigError({ code: ErrorCodes.AK_CONFIG_INVALID, message: `invalid cron step: "${segment}"` })
       range = segment.slice(0, stepIdx)
     }
     let from = min
@@ -76,9 +79,17 @@ function expandField(field: string, min: number, max: number): Set<number> {
         to = from
       }
     }
+    if (!Number.isInteger(from) || !Number.isInteger(to) || from < min || to > max || from > to) {
+      throw new ConfigError({ code: ErrorCodes.AK_CONFIG_INVALID, message: `cron value out of range: "${segment}"` })
+    }
     for (let i = from; i <= to; i += step) out.add(i)
   }
+  if (out.size === 0) throw new ConfigError({ code: ErrorCodes.AK_CONFIG_INVALID, message: `empty cron field: "${field}"` })
   return out
+}
+
+function isAnyField(field: string): boolean {
+  return field.split(',').some(segment => segment === '*' || segment.startsWith('*/'))
 }
 
 export function parseSchedule(schedule: string): ParsedSchedule {
@@ -109,17 +120,23 @@ export function parseSchedule(schedule: string): ParsedSchedule {
     dom: expandField(parts[2]!, 1, 31),
     month: expandField(parts[3]!, 1, 12),
     dow: expandField(parts[4]!, 0, 6),
+    domAny: isAnyField(parts[2]!),
+    dowAny: isAnyField(parts[4]!),
   }
 }
 
 export function cronMatches(schedule: ParsedCron, now: Date): boolean {
-  return (
-    schedule.minute.has(now.getMinutes()) &&
-    schedule.hour.has(now.getHours()) &&
-    schedule.dom.has(now.getDate()) &&
-    schedule.month.has(now.getMonth() + 1) &&
-    schedule.dow.has(now.getDay())
-  )
+  if (!schedule.minute.has(now.getMinutes()) || !schedule.hour.has(now.getHours()) || !schedule.month.has(now.getMonth() + 1)) return false
+  const domMatch = schedule.dom.has(now.getDate())
+  const dowMatch = schedule.dow.has(now.getDay())
+  const dayMatch = schedule.domAny && schedule.dowAny
+    ? true
+    : schedule.domAny
+      ? dowMatch
+      : schedule.dowAny
+        ? domMatch
+        : domMatch || dowMatch
+  return dayMatch
 }
 
 export interface CronScheduler {
@@ -217,6 +234,8 @@ export interface WebhookOptions<TContext = unknown> {
   context?: TContext | ((req: WebhookRequest) => TContext)
   /** Verify the incoming request (signature, token, etc.). */
   verify?: (req: WebhookRequest) => boolean | Promise<boolean>
+  /** Refuse construction without verification. Defaults to true. */
+  strict?: boolean
   onEvent?: (event: { type: 'received' | 'rejected' | 'handled'; error?: string }) => void
 }
 
@@ -236,22 +255,35 @@ export type WebhookHandler = (req: WebhookRequest) => Promise<WebhookResponse>
 export function createWebhookHandler<TContext = unknown>(
   options: WebhookOptions<TContext>,
 ): WebhookHandler {
+  if ((options.strict ?? true) && !options.verify) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'createWebhookHandler: verify is missing — refusing to construct an unverified webhook',
+      hint: 'Implement request verification or pass `{ strict: false }` when an external auth proxy is responsible.',
+    })
+  }
   return async req => {
     options.onEvent?.({ type: 'received' })
     if (options.verify) {
-      const ok = await options.verify(req)
+      let ok: boolean
+      try {
+        ok = await options.verify(req)
+      } catch {
+        options.onEvent?.({ type: 'rejected', error: 'verification failed' })
+        return { status: 500, body: 'internal error' }
+      }
       if (!ok) {
         options.onEvent?.({ type: 'rejected', error: 'verify returned false' })
         return { status: 401, body: 'unauthorized' }
       }
     }
-    const extract = options.extractTask ?? defaultExtract
-    const task = extract(req)
-    const context =
-      typeof options.context === 'function'
-        ? (options.context as (req: WebhookRequest) => TContext)(req)
-        : options.context
     try {
+      const extract = options.extractTask ?? defaultExtract
+      const task = extract(req)
+      const context =
+        typeof options.context === 'function'
+          ? (options.context as (req: WebhookRequest) => TContext)(req)
+          : options.context
       const result = await options.agent.run(task, context)
       options.onEvent?.({ type: 'handled' })
       return {
@@ -262,7 +294,7 @@ export function createWebhookHandler<TContext = unknown>(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       options.onEvent?.({ type: 'rejected', error: message })
-      return { status: 500, body: message }
+      return { status: 500, body: 'internal error' }
     }
   }
 }

--- a/packages/runtime/src/durable.ts
+++ b/packages/runtime/src/durable.ts
@@ -69,7 +69,7 @@ export function createDurableRunner(options: DurableRunnerOptions): DurableRunne
   const retryDelayMs = Math.max(0, options.retryDelayMs ?? 0)
   const { store, runId } = options
 
-  const step = async <TResult>(
+  const executeStep = async <TResult>(
     stepId: string,
     fn: () => Promise<TResult> | TResult,
     stepOpts: { name?: string } = {},
@@ -138,6 +138,30 @@ export function createDurableRunner(options: DurableRunnerOptions): DurableRunne
     throw lastError ?? new Error(`step "${stepId}" failed`)
   }
 
+  const inFlight = new Map<string, Promise<unknown>>()
+  const inFlightTokens = new Map<string, number>()
+  let nextToken = 0
+  const step = async <TResult>(
+    stepId: string,
+    fn: () => Promise<TResult> | TResult,
+    stepOpts: { name?: string } = {},
+  ): Promise<TResult> => {
+    const running = inFlight.get(stepId)
+    if (running) return running as Promise<TResult>
+    const execution = executeStep(stepId, fn, stepOpts)
+    const token = ++nextToken
+    inFlight.set(stepId, execution)
+    inFlightTokens.set(stepId, token)
+    try {
+      return await execution
+    } finally {
+      if (inFlightTokens.get(stepId) === token) {
+        inFlight.delete(stepId)
+        inFlightTokens.delete(stepId)
+      }
+    }
+  }
+
   return {
     step,
     async history() {
@@ -186,15 +210,31 @@ export async function createFileStepLog(path: string): Promise<StepLogStore> {
   }
 
   const load = async (): Promise<StepRecord<unknown>[]> => {
+    let raw: string
     try {
-      const raw = await readFile(path, 'utf8')
-      return raw
-        .split('\n')
-        .filter(Boolean)
-        .map(line => JSON.parse(line) as StepRecord<unknown>)
-    } catch {
-      return []
+      raw = await readFile(path, 'utf8')
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code === 'ENOENT') return []
+      throw new RuntimeError({
+        code: ErrorCodes.AK_RUNTIME_INVALID_INPUT,
+        message: 'durable step log could not be read',
+        cause,
+      })
     }
+    if (!raw.trim()) return []
+    const records: StepRecord<unknown>[] = []
+    for (const [index, line] of raw.split('\n').filter(Boolean).entries()) {
+      try {
+        records.push(JSON.parse(line) as StepRecord<unknown>)
+      } catch (cause) {
+        throw new RuntimeError({
+          code: ErrorCodes.AK_RUNTIME_INVALID_INPUT,
+          message: `durable step log is corrupt at line ${index + 1}`,
+          cause,
+        })
+      }
+    }
+    return records
   }
 
   return {

--- a/packages/runtime/src/durable.ts
+++ b/packages/runtime/src/durable.ts
@@ -64,6 +64,21 @@ export interface DurableRunner {
   reset: () => Promise<void>
 }
 
+function isStepRecord(input: unknown): input is StepRecord<unknown> {
+  if (input === null || typeof input !== 'object') return false
+  const record = input as Partial<StepRecord<unknown>>
+  return (
+    typeof record.runId === 'string' && record.runId.length > 0 &&
+    typeof record.stepId === 'string' && record.stepId.length > 0 &&
+    typeof record.name === 'string' && record.name.length > 0 &&
+    (record.status === 'success' || record.status === 'failure') &&
+    (record.error === undefined || typeof record.error === 'string') &&
+    typeof record.startedAt === 'string' && record.startedAt.length > 0 &&
+    typeof record.endedAt === 'string' && record.endedAt.length > 0 &&
+    typeof record.attempt === 'number' && Number.isSafeInteger(record.attempt) && record.attempt >= 1
+  )
+}
+
 export function createDurableRunner(options: DurableRunnerOptions): DurableRunner {
   const maxAttempts = Math.max(1, options.maxAttempts ?? 1)
   const retryDelayMs = Math.max(0, options.retryDelayMs ?? 0)
@@ -225,7 +240,14 @@ export async function createFileStepLog(path: string): Promise<StepLogStore> {
     const records: StepRecord<unknown>[] = []
     for (const [index, line] of raw.split('\n').filter(Boolean).entries()) {
       try {
-        records.push(JSON.parse(line) as StepRecord<unknown>)
+        const record: unknown = JSON.parse(line)
+        if (!isStepRecord(record)) {
+          throw new RuntimeError({
+            code: ErrorCodes.AK_RUNTIME_INVALID_INPUT,
+            message: 'invalid step record',
+          })
+        }
+        records.push(record)
       } catch (cause) {
         throw new RuntimeError({
           code: ErrorCodes.AK_RUNTIME_INVALID_INPUT,

--- a/packages/runtime/src/quota.ts
+++ b/packages/runtime/src/quota.ts
@@ -55,10 +55,12 @@ export interface QuotaTrackerOptions {
 }
 
 export interface QuotaTracker {
-  /** Throws ToolError(`AK_TOOL_QUOTA_EXCEEDED`) when the tool is over budget. */
+  /** Throws and reserves one admission when the tool is over budget. */
   check: (tool: string, runId: string) => void
   /** Records a successful tool invocation against the counters. */
   record: (tool: string, runId: string) => void
+  /** Releases an admission when tool execution fails before it completes. */
+  release: (tool: string, runId: string) => void
   /** Reset per-run counters for a finished `runtime.run()`. */
   resetRun: (runId: string) => void
   /** Inspect counters (debugging / dashboards). */
@@ -74,6 +76,9 @@ export function createQuotaTracker(options: QuotaTrackerOptions): QuotaTracker {
   const now = options.now ?? (() => Date.now())
   const perRun = new Map<string, Map<string, number>>()
   const perWindow = new Map<string, number[]>()
+  const pending = new Map<string, Array<{ windowAt?: number }>>()
+
+  const pendingKey = (tool: string, runId: string) => `${runId}\0${tool}`
 
   function trim(tool: string, windowMs: number): void {
     const cutoff = now() - windowMs
@@ -106,18 +111,19 @@ export function createQuotaTracker(options: QuotaTrackerOptions): QuotaTracker {
       if (quota.perRun != null) {
         const runMap = perRun.get(runId) ?? new Map<string, number>()
         const current = runMap.get(tool) ?? 0
-        if (current >= quota.perRun) {
+        const inFlight = pending.get(pendingKey(tool, runId))?.length ?? 0
+        if (current + inFlight >= quota.perRun) {
           const event: QuotaExceededEvent = {
             tool,
             kind: 'perRun',
             limit: quota.perRun,
-            observed: current,
+            observed: current + inFlight,
             at: new Date(now()).toISOString(),
           }
           options.onExceeded?.(event)
           throw new ToolError({
             code: ErrorCodes.AK_TOOL_QUOTA_EXCEEDED,
-            message: `Tool "${tool}" exceeded per-run quota (${current}/${quota.perRun})`,
+            message: `Tool "${tool}" exceeded per-run quota (${current + inFlight}/${quota.perRun})`,
             hint: 'Lower the agent\'s steps, split the work across runs, or raise the quota.',
           })
         }
@@ -141,11 +147,27 @@ export function createQuotaTracker(options: QuotaTrackerOptions): QuotaTracker {
           })
         }
       }
+
+      const key = pendingKey(tool, runId)
+      const reservations = pending.get(key) ?? []
+      const reservation = quota.perWindow ? { windowAt: now() } : {}
+      if (quota.perWindow) {
+        const arr = perWindow.get(tool) ?? []
+        arr.push(reservation.windowAt!)
+        if (arr.length > 0 || perWindow.has(tool)) perWindow.set(tool, arr)
+      }
+      reservations.push(reservation)
+      pending.set(key, reservations)
     },
 
     record(tool, runId) {
       const quota = options.quotas[tool]
       if (!quota) return
+
+      const key = pendingKey(tool, runId)
+      const reservations = pending.get(key)
+      const reservation = reservations?.pop()
+      if (reservations && reservations.length === 0) pending.delete(key)
 
       if (quota.perRun != null) {
         const runMap = perRun.get(runId) ?? new Map<string, number>()
@@ -153,14 +175,46 @@ export function createQuotaTracker(options: QuotaTrackerOptions): QuotaTracker {
         perRun.set(runId, runMap)
       }
       if (quota.perWindow) {
+        if (reservation?.windowAt == null) {
+          const arr = perWindow.get(tool) ?? []
+          arr.push(now())
+          perWindow.set(tool, arr)
+        }
+      }
+    },
+
+    release(tool, runId) {
+      const quota = options.quotas[tool]
+      if (!quota) return
+
+      const key = pendingKey(tool, runId)
+      const reservations = pending.get(key)
+      const reservation = reservations?.pop()
+      if (!reservation) return
+      if (reservations && reservations.length === 0) pending.delete(key)
+
+      if (reservation.windowAt != null) {
         const arr = perWindow.get(tool) ?? []
-        arr.push(now())
+        const index = arr.indexOf(reservation.windowAt)
+        if (index >= 0) arr.splice(index, 1)
         perWindow.set(tool, arr)
       }
     },
 
     resetRun(runId) {
       perRun.delete(runId)
+      for (const [key, reservations] of pending) {
+        if (!key.startsWith(`${runId}\0`)) continue
+        const tool = key.slice(runId.length + 1)
+        const arr = perWindow.get(tool) ?? []
+        for (const reservation of reservations) {
+          if (reservation.windowAt == null) continue
+          const index = arr.indexOf(reservation.windowAt)
+          if (index >= 0) arr.splice(index, 1)
+        }
+        perWindow.set(tool, arr)
+        pending.delete(key)
+      }
     },
 
     snapshot() {
@@ -195,9 +249,14 @@ export function withQuotas(
       execute: async (args, context) => {
         const runId = runIdFor(context)
         tracker.check(tool.name, runId)
-        const result = await (original as (a: unknown, c: ToolExecutionContext) => unknown)(args, context)
-        tracker.record(tool.name, runId)
-        return result
+        try {
+          const result = await (original as (a: unknown, c: ToolExecutionContext) => unknown)(args, context)
+          tracker.record(tool.name, runId)
+          return result
+        } catch (error) {
+          tracker.release(tool.name, runId)
+          throw error
+        }
       },
     } as ToolDefinition
   })

--- a/packages/runtime/src/quota.ts
+++ b/packages/runtime/src/quota.ts
@@ -185,7 +185,7 @@ export function createQuotaTracker(options: QuotaTrackerOptions): QuotaTracker {
 export function withQuotas(
   tools: ToolDefinition[],
   tracker: QuotaTracker,
-  runIdFor: (context: ToolExecutionContext) => string = ctx => ctx.call.id,
+  runIdFor: (context: ToolExecutionContext) => string = ctx => ctx.runId ?? ctx.call.id,
 ): ToolDefinition[] {
   return tools.map(tool => {
     if (!tool.execute) return tool

--- a/packages/runtime/src/runner.ts
+++ b/packages/runtime/src/runner.ts
@@ -8,6 +8,8 @@ import {
   buildToolMap,
   activateSkills,
   executeSafeTool,
+  ConfigError,
+  ErrorCodes,
 } from '@agentskit/core'
 import type {
   AdapterRequest,
@@ -42,6 +44,18 @@ function normalizeLlmUsage(
 
 function isAborted(signal?: AbortSignal): boolean {
   return signal?.aborted === true
+}
+
+let runIdCounter = 0
+
+function validateMaxSteps(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: `${label} must be a finite positive integer`,
+    })
+  }
+  return value
 }
 
 async function consumeStreamWithAbort(
@@ -94,7 +108,10 @@ export function createRuntime(config: RuntimeConfig) {
   ): Promise<RunResult> {
     const startTime = Date.now()
 
-    const maxSteps = options?.maxSteps ?? config.maxSteps ?? 10
+    const configuredMaxSteps = validateMaxSteps(config.maxSteps ?? 10, 'maxSteps')
+    const requestedMaxSteps = options?.maxSteps
+    if (requestedMaxSteps !== undefined) validateMaxSteps(requestedMaxSteps, 'run maxSteps')
+    const maxSteps = Math.min(configuredMaxSteps, requestedMaxSteps ?? configuredMaxSteps)
     const signal = options?.signal
 
     // Activate skill: use skill's systemPrompt directly, activate tools via shared helper
@@ -134,6 +151,7 @@ export function createRuntime(config: RuntimeConfig) {
             maxSteps: delegateConfig.maxSteps ?? 5,
             signal,
             sharedContext: options?.sharedContext,
+            runId: options?.runId,
           }
 
           const result = await childRuntime.run(delegateTask, childOptions)
@@ -300,7 +318,7 @@ export function createRuntime(config: RuntimeConfig) {
           const execResult = await executeSafeTool({
             tool,
             toolCall,
-            context: { messages, call: toolCall },
+            context: { messages, call: toolCall, runId: options?.runId },
             emitter,
             lifecycle,
             validate: config.validateArgs,
@@ -373,7 +391,8 @@ export function createRuntime(config: RuntimeConfig) {
 
   return {
     run(task: string, options?: RunOptions): Promise<RunResult> {
-      return runInternal(task, options, 0)
+      const runId = options?.runId ?? `run-${Date.now()}-${++runIdCounter}`
+      return runInternal(task, { ...options, runId }, 0)
     },
   }
 }

--- a/packages/runtime/src/topologies.ts
+++ b/packages/runtime/src/topologies.ts
@@ -14,6 +14,8 @@ import { ConfigError, ErrorCodes, RuntimeError } from '@agentskit/core'
 export interface AgentHandle<TContext = unknown> {
   name: string
   run: (task: string, context?: TContext) => Promise<string>
+  /** Best-effort cancellation hook used when a topology deadline expires. */
+  abort?: () => void
 }
 
 export interface TopologyLogEvent {
@@ -95,10 +97,18 @@ export interface SwarmConfig<TContext = unknown> {
   onEvent?: TopologyObserver
 }
 
-function withTimeout<T>(p: Promise<T>, timeoutMs: number | undefined, label: string): Promise<T> {
+function withTimeout<T>(
+  p: Promise<T>,
+  timeoutMs: number | undefined,
+  label: string,
+  onTimeout?: () => void,
+): Promise<T> {
   if (timeoutMs === undefined) return p
   return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs)
+    const timer = setTimeout(() => {
+      onTimeout?.()
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
     p.then(
       v => {
         clearTimeout(timer)
@@ -131,7 +141,7 @@ export function swarm<TContext = unknown>(config: SwarmConfig<TContext>): AgentH
       const settled = await Promise.allSettled(
         config.members.map(async m => {
           config.onEvent?.({ topology: 'swarm', phase: 'agent:start', agent: m.name })
-          const output = await withTimeout(m.run(task, context), config.timeoutMs, `swarm(${m.name})`)
+          const output = await withTimeout(m.run(task, context), config.timeoutMs, `swarm(${m.name})`, m.abort)
           config.onEvent?.({ topology: 'swarm', phase: 'agent:end', agent: m.name, result: output })
           return { agent: m.name, output }
         }),

--- a/packages/runtime/src/topologies.ts
+++ b/packages/runtime/src/topologies.ts
@@ -106,7 +106,11 @@ function withTimeout<T>(
   if (timeoutMs === undefined) return p
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => {
-      onTimeout?.()
+      try {
+        onTimeout?.()
+      } catch {
+        // Cancellation is best-effort; the timeout must still settle the wrapper.
+      }
       reject(new Error(`${label} timed out after ${timeoutMs}ms`))
     }, timeoutMs)
     p.then(

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -46,6 +46,8 @@ export interface RunOptions {
   systemPrompt?: string
   skill?: SkillDefinition
   maxSteps?: number
+  /** Stable identifier shared by all tool calls in this run. */
+  runId?: string
   signal?: AbortSignal
   delegates?: Record<string, DelegateConfig>
   sharedContext?: SharedContext

--- a/packages/runtime/src/validator-guard.ts
+++ b/packages/runtime/src/validator-guard.ts
@@ -202,8 +202,13 @@ export function denyPattern(pattern: RegExp, name = 'deny-pattern'): Validator {
   return {
     name,
     check: ({ output }) => {
-      if (pattern.test(output)) return { ok: false, reason: `output matched deny pattern ${pattern}` }
-      return true
+      pattern.lastIndex = 0
+      try {
+        if (pattern.test(output)) return { ok: false, reason: `output matched deny pattern ${pattern}` }
+        return true
+      } finally {
+        pattern.lastIndex = 0
+      }
     },
     onFail: 'block',
   }

--- a/packages/runtime/tests/background.test.ts
+++ b/packages/runtime/tests/background.test.ts
@@ -52,6 +52,8 @@ describe('parseSchedule', () => {
     expect(() => parseSchedule('0 9')).toThrow(/5 fields/)
     expect(() => parseSchedule('every:-1')).toThrow(/invalid every:/)
     expect(() => parseSchedule('99 * * * *')).toThrow(/out of range/)
+    expect(() => parseSchedule('0,,5 * * * *')).toThrow(/empty cron segment/)
+    expect(() => parseSchedule('0 0 1-2-3 * *')).toThrow(/invalid cron range/)
   })
 })
 

--- a/packages/runtime/tests/background.test.ts
+++ b/packages/runtime/tests/background.test.ts
@@ -51,6 +51,7 @@ describe('parseSchedule', () => {
   it('rejects malformed cron', () => {
     expect(() => parseSchedule('0 9')).toThrow(/5 fields/)
     expect(() => parseSchedule('every:-1')).toThrow(/invalid every:/)
+    expect(() => parseSchedule('99 * * * *')).toThrow(/out of range/)
   })
 })
 
@@ -60,6 +61,13 @@ describe('cronMatches', () => {
     if (p.type !== 'cron') throw new Error()
     expect(cronMatches(p, new Date(2026, 0, 1, 9, 30))).toBe(true)
     expect(cronMatches(p, new Date(2026, 0, 1, 9, 31))).toBe(false)
+  })
+
+  it('uses standard OR semantics for restricted day-of-month/day-of-week', () => {
+    const p = parseSchedule('0 0 1 * 1')
+    if (p.type !== 'cron') throw new Error()
+    expect(cronMatches(p, new Date(2026, 8, 1, 0, 0))).toBe(true)
+    expect(cronMatches(p, new Date(2026, 8, 7, 0, 0))).toBe(true)
   })
 })
 
@@ -155,14 +163,14 @@ describe('createCronScheduler', () => {
 
 describe('createWebhookHandler', () => {
   it('passes extracted task to the agent and returns 200 + body', async () => {
-    const handler = createWebhookHandler({ agent: agent('a', async t => `ran: ${t}`) })
+    const handler = createWebhookHandler({ agent: agent('a', async t => `ran: ${t}`), strict: false })
     const res = await handler({ body: 'hello' })
     expect(res.status).toBe(200)
     expect(res.body).toBe('ran: hello')
   })
 
   it('extracts .task from JSON body by default', async () => {
-    const handler = createWebhookHandler({ agent: agent('a', async t => t) })
+    const handler = createWebhookHandler({ agent: agent('a', async t => t), strict: false })
     const res = await handler({ body: { task: 'from-json' } as Record<string, unknown> })
     expect(res.body).toBe('from-json')
   })
@@ -171,6 +179,7 @@ describe('createWebhookHandler', () => {
     const handler = createWebhookHandler({
       agent: agent('a', async t => t),
       extractTask: (req: WebhookRequest) => (req.headers?.['x-task'] as string) ?? '',
+      strict: false,
     })
     const res = await handler({ headers: { 'x-task': 'header-task' } })
     expect(res.body).toBe('header-task')
@@ -185,19 +194,38 @@ describe('createWebhookHandler', () => {
     expect(res.status).toBe(401)
   })
 
+  it('contains verifier failures and emits a sanitized rejection', async () => {
+    const events: string[] = []
+    const handler = createWebhookHandler({
+      agent: agent('a'),
+      verify: async () => { throw new Error('secret verifier detail') },
+      onEvent: e => events.push(`${e.type}:${e.error ?? ''}`),
+    })
+    const res = await handler({ body: 'x' })
+    expect(res).toEqual({ status: 500, body: 'internal error' })
+    expect(events).toEqual(['received:', 'rejected:verification failed'])
+  })
+
+  it('refuses construction without verification unless strict:false is explicit', () => {
+    expect(() => createWebhookHandler({ agent: agent('a') })).toThrow(/verify is missing/)
+    expect(() => createWebhookHandler({ agent: agent('a'), strict: false })).not.toThrow()
+  })
+
   it('returns 500 + message on agent failure', async () => {
     const handler = createWebhookHandler({
       agent: { name: 'bad', run: async () => { throw new Error('kaboom') } },
+      strict: false,
     })
     const res = await handler({ body: 'x' })
     expect(res.status).toBe(500)
-    expect(res.body).toBe('kaboom')
+    expect(res.body).toBe('internal error')
   })
 
   it('fires received + handled events on success', async () => {
     const events: string[] = []
     const handler = createWebhookHandler({
       agent: agent('a'),
+      strict: false,
       onEvent: e => events.push(e.type),
     })
     await handler({ body: 'x' })

--- a/packages/runtime/tests/durable.test.ts
+++ b/packages/runtime/tests/durable.test.ts
@@ -181,4 +181,18 @@ describe('createFileStepLog', () => {
       rmSync(dir, { recursive: true, force: true })
     }
   })
+
+  it('rejects valid JSON that is not a step record', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ak-dur-'))
+    const path = join(dir, 'log.jsonl')
+    try {
+      writeFileSync(path, '{"runId":"r","stepId":"s","status":"success"}\n')
+      const store = await createFileStepLog(path)
+      await expect(store.list('r')).rejects.toMatchObject({
+        code: 'AK_RUNTIME_INVALID_INPUT',
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })

--- a/packages/runtime/tests/durable.test.ts
+++ b/packages/runtime/tests/durable.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -49,6 +49,19 @@ describe('createDurableRunner', () => {
     const replayed = await r2.step('x', fn)
     expect(replayed).toBe(42)
     expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('single-flights concurrent calls for one step id', async () => {
+    const runner = createDurableRunner({ store: createInMemoryStepLog(), runId: 'r1' })
+    let calls = 0
+    const fn = async () => {
+      calls++
+      await new Promise(resolve => setTimeout(resolve, 5))
+      return 42
+    }
+    const results = await Promise.all([runner.step('x', fn), runner.step('x', fn)])
+    expect(results).toEqual([42, 42])
+    expect(calls).toBe(1)
   })
 
   it('emits step:replay events on cache hits', async () => {
@@ -150,6 +163,20 @@ describe('createFileStepLog', () => {
       await store.clear?.('a')
       expect(await store.list('a')).toHaveLength(0)
       expect(await store.list('b')).toHaveLength(1)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not treat a corrupt log as an empty history', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ak-dur-'))
+    const path = join(dir, 'log.jsonl')
+    try {
+      writeFileSync(path, '{not-json}\n')
+      const store = await createFileStepLog(path)
+      await expect(store.list('r')).rejects.toMatchObject({
+        code: 'AK_RUNTIME_INVALID_INPUT',
+      })
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/packages/runtime/tests/quota.test.ts
+++ b/packages/runtime/tests/quota.test.ts
@@ -106,4 +106,13 @@ describe('withQuotas', () => {
     expect(calls).toBe(1)
     await expect(wrapped.execute!({}, ctx)).rejects.toThrow(/per-run quota/)
   })
+
+  it('uses the parent runtime run id by default', async () => {
+    const tracker = createQuotaTracker({ quotas: { send: { perRun: 1 } } })
+    const tool = defineTool({ name: 'send', execute: async () => 'ok' })
+    const [wrapped] = withQuotas([tool], tracker)
+    const context = { messages: [], runId: 'run-1', call: { id: 'call-1', name: 'send', args: {}, status: 'running' as const } }
+    await wrapped.execute!({}, context)
+    await expect(wrapped.execute!({}, { ...context, call: { ...context.call, id: 'call-2' } })).rejects.toThrow(/per-run quota/)
+  })
 })

--- a/packages/runtime/tests/quota.test.ts
+++ b/packages/runtime/tests/quota.test.ts
@@ -115,4 +115,30 @@ describe('withQuotas', () => {
     await wrapped.execute!({}, context)
     await expect(wrapped.execute!({}, { ...context, call: { ...context.call, id: 'call-2' } })).rejects.toThrow(/per-run quota/)
   })
+
+  it('does not admit concurrent calls beyond the per-run cap', async () => {
+    const tracker = createQuotaTracker({ quotas: { send: { perRun: 1 } } })
+    let finish!: () => void
+    const tool = defineTool({
+      name: 'send',
+      execute: () => new Promise(resolve => { finish = () => resolve('ok') }),
+    })
+    const [wrapped] = withQuotas([tool], tracker, () => 'r1')
+
+    const first = wrapped.execute!({}, { messages: [], call: { id: '1', name: 'send', args: {}, status: 'running' as const } })
+    await expect(wrapped.execute!({}, { messages: [], call: { id: '2', name: 'send', args: {}, status: 'running' as const } })).rejects.toThrow(/per-run quota/)
+    finish()
+    await first
+  })
+
+  it('releases a reservation when execution fails', async () => {
+    const tracker = createQuotaTracker({ quotas: { send: { perRun: 1 } } })
+    const tool = defineTool({ name: 'send', execute: async () => { throw new Error('failed') } })
+    const [wrapped] = withQuotas([tool], tracker, () => 'r1')
+    const context = { messages: [], call: { id: '1', name: 'send', args: {}, status: 'running' as const } }
+
+    await expect(wrapped.execute!({}, context)).rejects.toThrow('failed')
+    expect(tracker.snapshot().perRun).toEqual({})
+    tracker.check('send', 'r1')
+  })
 })

--- a/packages/runtime/tests/runner.test.ts
+++ b/packages/runtime/tests/runner.test.ts
@@ -248,6 +248,31 @@ describe('createRuntime', () => {
       const result = await runtime.run('loop', { maxSteps: 2 })
       expect(result.steps).toBe(2)
     })
+
+    it('never lets a per-run value raise the configured cap', async () => {
+      const adapter: ReturnType<typeof createMockAdapter> = {
+        createSource: () => ({
+          stream: async function* () {
+            yield { type: 'tool_call' as const, toolCall: { id: `tc-${Date.now()}`, name: 'loop', args: '{}' } }
+            yield { type: 'done' as const }
+          },
+          abort: () => {},
+        }),
+      }
+      const runtime = createRuntime({
+        adapter,
+        tools: [{ name: 'loop', execute: async () => 'again' }],
+        maxSteps: 2,
+      })
+      await expect(runtime.run('loop', { maxSteps: 20 })).resolves.toMatchObject({ steps: 2 })
+    })
+
+    it('rejects invalid maxSteps before the adapter runs', async () => {
+      const createSource = vi.fn(() => createMockAdapter([{ type: 'done' }]).createSource({ messages: [], context: {} }))
+      const runtime = createRuntime({ adapter: { createSource } })
+      await expect(runtime.run('bad', { maxSteps: 0 })).rejects.toMatchObject({ code: 'AK_CONFIG_INVALID' })
+      expect(createSource).not.toHaveBeenCalled()
+    })
   })
 
   describe('tool error injection', () => {

--- a/packages/runtime/tests/topologies.test.ts
+++ b/packages/runtime/tests/topologies.test.ts
@@ -118,6 +118,16 @@ describe('swarm', () => {
     expect(await s.run('t')).toBe('quick')
   })
 
+  it('calls a member abort hook when its deadline expires', async () => {
+    const abort = vi.fn()
+    const s = swarm({
+      members: [{ name: 'slow', run: () => new Promise<string>(() => undefined), abort }],
+      timeoutMs: 10,
+    })
+    await expect(s.run('t')).rejects.toThrow(/every swarm member failed/)
+    expect(abort).toHaveBeenCalledOnce()
+  })
+
   it('rejects empty members', () => {
     expect(() => swarm({ members: [] })).toThrow(/≥ 1 member/)
   })

--- a/packages/runtime/tests/topologies.test.ts
+++ b/packages/runtime/tests/topologies.test.ts
@@ -128,6 +128,14 @@ describe('swarm', () => {
     expect(abort).toHaveBeenCalledOnce()
   })
 
+  it('still rejects on timeout when a member abort hook throws', async () => {
+    const s = swarm({
+      members: [{ name: 'slow', run: () => new Promise<string>(() => undefined), abort: () => { throw new Error('abort failed') } }],
+      timeoutMs: 10,
+    })
+    await expect(s.run('t')).rejects.toThrow(/every swarm member failed/)
+  })
+
   it('rejects empty members', () => {
     expect(() => swarm({ members: [] })).toThrow(/≥ 1 member/)
   })

--- a/packages/runtime/tests/validator-guard.test.ts
+++ b/packages/runtime/tests/validator-guard.test.ts
@@ -83,4 +83,12 @@ describe('createValidatorGuard', () => {
     expect(result.output).toBe('seeded')
     expect(regen).not.toHaveBeenCalled()
   })
+
+  it('resets global and sticky deny patterns between checks', async () => {
+    const guard = createValidatorGuard({ validators: [denyPattern(/secret/gy)] })
+    const first = await guard.run({ regenerate: async () => 'secret' })
+    const second = await guard.run({ regenerate: async () => 'secret' })
+    expect(first.accepted).toBe(false)
+    expect(second.accepted).toBe(false)
+  })
 })

--- a/packages/statechart/CHANGELOG.md
+++ b/packages/statechart/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @agentskit/statechart
 
+## 0.3.0
+
+### Patch Changes
+
+- Harden definition freezing so every validated state and transition is retained.
+- Reject non-boolean guard results without accepting the transition.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/statechart/src/definition.ts
+++ b/packages/statechart/src/definition.ts
@@ -70,14 +70,16 @@ const freezeDefinition = <
     Record<TState, StatechartState<TContext, TEvent, TState>>
   >
 
-  for (const stateName of Object.keys(input.states) as TState[]) {
-    const state = input.states[stateName]
+  for (const [stateName, state] of dataEntries(input.states, 'states') as Array<[
+    TState,
+    StatechartState<TContext, TEvent, TState>
+  ]>) {
     const on = Object.create(null) as Record<
       string,
       StatechartTransition<TContext, TEvent, TState>
     >
 
-    const transitions = Object.entries(state.on ?? {}) as Array<
+    const transitions = dataEntries((state.on ?? {}) as Record<string, unknown>, `state "${stateName}" transitions`) as Array<
       [string, StatechartTransition<TContext, TEvent, TState> | undefined]
     >
     for (const [eventType, transition] of transitions) {

--- a/packages/statechart/src/statechart.ts
+++ b/packages/statechart/src/statechart.ts
@@ -175,7 +175,9 @@ export const transitionStatechart = <
 
   if (candidate.guard !== undefined) {
     try {
-      if (!candidate.guard(instance.context, frozenEvent)) {
+      const allowed = candidate.guard(instance.context, frozenEvent)
+      if (typeof allowed !== 'boolean') throw new TypeError('guard must return a boolean synchronously')
+      if (!allowed) {
         return rejectTransition(
           instance,
           frozenEvent,

--- a/packages/statechart/tests/statechart.test.ts
+++ b/packages/statechart/tests/statechart.test.ts
@@ -189,6 +189,19 @@ describe('definitions and instances', () => {
     expect(({} as { target?: string }).target).toBeUndefined()
   })
 
+  it('preserves non-enumerable data entries in the frozen definition', () => {
+    const states = { idle: {} } as Record<string, unknown>
+    Object.defineProperty(states, 'done', { value: {}, enumerable: false })
+    const definition = defineStatechart<JsonObject, StatechartEvent<'go'>, 'idle' | 'done'>({
+      id: 'hidden-state',
+      initial: 'idle',
+      parseContext: input => input as JsonObject,
+      states: states as never,
+      version: '1',
+    })
+    expect(Object.prototype.hasOwnProperty.call(definition.states, 'done')).toBe(true)
+  })
+
   it.each([
     [null, 'definition'],
     [{ id: 1, initial: 'idle', parseContext: (input: unknown) => input, states: { idle: {} }, version: '1' }, 'id'],
@@ -335,6 +348,26 @@ describe('transitionStatechart', () => {
       status: 'rejected',
     })
     expect(JSON.stringify(result)).not.toContain('not public')
+  })
+
+  it('rejects thenable and non-boolean guard results', () => {
+    const makeMachine = (guard: () => unknown) => defineStatechart<JsonObject, StatechartEvent<'go'>, 'idle'>({
+      id: `guard-${Math.random()}`,
+      initial: 'idle',
+      parseContext: input => input as JsonObject,
+      states: { idle: { on: { go: { guard: guard as () => boolean, target: 'idle' } } } },
+      version: '1',
+    })
+    for (const guard of [() => Promise.resolve(false), () => 1]) {
+      const definition = makeMachine(guard)
+      const result = transitionStatechart(
+        definition,
+        createStatechartInstance(definition, {}, { instanceId: '1', now: '0' }),
+        { type: 'go' },
+        { now: '1' },
+      )
+      expect(result).toMatchObject({ status: 'rejected', diagnostic: { code: StatechartDiagnosticCodes.GUARD_FAILED } })
+    }
   })
 
   it('distinguishes reducer exceptions from invalid reducer output', () => {

--- a/packages/statechart/vitest.config.ts
+++ b/packages/statechart/vitest.config.ts
@@ -1,4 +1,4 @@
 import { createTestConfig } from '../../vitest.shared'
 import { defineConfig } from 'vitest/config'
 
-export default defineConfig(createTestConfig({ linesThreshold: 90 }))
+export default defineConfig(createTestConfig({ linesThreshold: 95 }))


### PR DESCRIPTION
## Summary

This stacked PR isolates the `@agentskit/runtime` and `@agentskit/statechart` remediation batch. It is based on the core and tools/MCP PRs.

## Changes

- Hardened runtime deadlines, replay/scheduling, durable-step lifecycle, quotas, and runner boundaries.
- Hardened statechart definition and transition contracts.
- Added regression coverage for reuse, replay, and scheduling paths.
- Updated the related agent and reference documentation.
- Added a release changeset for runtime and statechart.

## Verification

- Runtime tests: 187/187 passed.
- Statechart tests: 51/51 passed in the focused batch.
- Runtime/statechart coverage and package builds passed in the source branch.

## Scope

- No external issues were created, edited, or closed.
- No publication or deployment was performed.
- `ak-verify` remains unavailable; formal finding resolution is not claimed.
