### PR TITLE
fix(adapters): harden CLI boundaries

### DIFF
--- a/.changeset/adapters-remediation.md
+++ b/.changeset/adapters-remediation.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/adapters': patch
+---
+
+Harden configurable CLI adapter transports, provider manifests, deadlines, cancellation, and bounded output handling.

--- a/docs/architecture/adrs/0031-cli-adapter-execution-boundary.md
+++ b/docs/architecture/adrs/0031-cli-adapter-execution-boundary.md
@@ -93,14 +93,15 @@ terminal commands in safe mode.
 It may use a provider's native login and local configuration, but it is not an
 isolation boundary and must be visible in diagnostics and audit metadata.
 
-`isolated` is available when a provider accepts explicit credentials and a
-minimal environment. It is not advertised as a sandbox: the adapter cannot
-claim filesystem or kernel isolation it does not provide.
+`restricted-environment` is available when a provider accepts explicit
+credentials and a minimal environment. It is an environment allowlist, not a
+sandbox: the adapter cannot claim filesystem, process, network, or kernel
+isolation it does not provide.
 
 Authentication is therefore explicit per mode: AgentsKit credentials for API
-adapters, a declared credential for `isolated`, and native provider login only
-for `trusted-local`. Secrets are redacted from diagnostics, errors, and
-persisted metadata.
+adapters, a declared credential for `restricted-environment`, and native
+provider login only for `trusted-local`. Secrets are redacted from diagnostics,
+errors, and persisted metadata.
 
 ### Capabilities and options
 

--- a/docs/evidence/ecosystem-documentation-quality/agentskit.json
+++ b/docs/evidence/ecosystem-documentation-quality/agentskit.json
@@ -4,7 +4,7 @@
   "profileVersion": 1,
   "productId": "agentskit",
   "repo": "AgentsKit-io/agentskit",
-  "commit": "19c57b8d0584f194c9f11421aa7ac15b048168a8",
+  "commit": "e96ebe625ca1c86e9a5cfef26fcc2b3387c81678",
   "auditedOn": "2026-09-02",
   "docBridge": {
     "artifact": "docs/evidence/ecosystem-documentation-quality/doc-bridge/agentskit.json",

--- a/docs/evidence/ecosystem-documentation-quality/doc-bridge/agentskit.json
+++ b/docs/evidence/ecosystem-documentation-quality/doc-bridge/agentskit.json
@@ -3,7 +3,7 @@
   "protocol": "agentskit.doc-bridge.attestation",
   "productId": "agentskit",
   "repo": "AgentsKit-io/agentskit",
-  "commit": "19c57b8d0584f194c9f11421aa7ac15b048168a8",
+  "commit": "e96ebe625ca1c86e9a5cfef26fcc2b3387c81678",
   "sourceMode": "commit",
   "contentDigest": "sha256:5449ff13a160cb8d2255266a0828d1c48eb7fc514abca54214d805c7ddf152b2",
   "command": "pnpm docs:bridge:doctor && pnpm docs:bridge:gate",

--- a/packages/adapters/CONVENTIONS.md
+++ b/packages/adapters/CONVENTIONS.md
@@ -6,8 +6,12 @@ The provider layer. Every file in this package maps one LLM or one embedding pro
 
 - **Chat adapters** — implement `AdapterFactory` per [ADR 0001](../../docs/architecture/adrs/0001-adapter-contract.md)
 - **Embedders** — implement `EmbedFn` per [ADR 0003](../../docs/architecture/adrs/0003-memory-contract.md)
-- **No UI.** No React, no Ink, no CLI here.
-- **No runtime logic.** No loops, no tool execution. Just transport.
+- **No UI.** No React or Ink here.
+- **CLI boundary:** `src/cli` contains process/transport adapters for external
+  developer CLIs; it must remain shell-free, bounded, and explicit about the
+  fact that `restricted-environment` is not OS or filesystem isolation.
+- **No agent runtime orchestration.** Provider adapters may own transport
+  retries, parsing, and cancellation, but not agent loops or tool policy.
 
 ## Adding a new chat adapter
 

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -117,6 +117,9 @@ spawning, and `onDiagnostic` receives redacted exit, timeout, abort, and
 output-limit data. Structured output fails closed; timeouts, aborts, output
 limits, and non-zero exits produce terminal adapter errors. Process termination
 is awaited before the adapter finishes, including when input or output fails.
+`restricted-environment` is an explicit environment allowlist mode; it is not
+an OS, filesystem, process, or network sandbox. Use `@agentskit/sandbox` when a
+real isolation boundary is required.
 
 Use `buildArgs(request)` only for CLIs that require the prompt in argv; it is
 request-aware and still uses direct, shell-free spawning. Set

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -56,7 +56,7 @@
   ],
   "scripts": {
     "build": "tsup",
-    "test": "pnpm --filter @agentskit/core build && pnpm run build && vitest run",
+    "test": "pnpm --filter @agentskit/core build && pnpm --filter @agentskit/integrations build && pnpm --filter @agentskit/tools build && pnpm run build && vitest run",
     "test:coverage": "vitest run --coverage",
     "lint": "tsc --noEmit",
     "dev": "tsup --watch"

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -56,7 +56,7 @@
   ],
   "scripts": {
     "build": "tsup",
-    "test": "vitest run",
+    "test": "pnpm --filter @agentskit/core build && pnpm run build && vitest run",
     "test:coverage": "vitest run --coverage",
     "lint": "tsc --noEmit",
     "dev": "tsup --watch"

--- a/packages/adapters/src/cli/manifests.ts
+++ b/packages/adapters/src/cli/manifests.ts
@@ -36,7 +36,7 @@ export interface CliManifestOptions {
   requiredCapabilities?: CliCapabilityRequirements
 }
 
-const MODES: readonly CliSecurityMode[] = ['review-safe', 'trusted-local', 'isolated']
+const MODES: readonly CliSecurityMode[] = ['review-safe', 'trusted-local', 'restricted-environment']
 const CAPABILITIES = new Set<keyof CliCapabilityRequirements>([
   'streaming', 'structuredOutput', 'reasoning', 'tools', 'mcp', 'plugins', 'terminal', 'nativeAuth',
 ])

--- a/packages/adapters/src/cli/process.ts
+++ b/packages/adapters/src/cli/process.ts
@@ -25,10 +25,10 @@ export interface CliProcessHandle {
 }
 
 function validateOptions(options: CliProcessOptions): void {
-  if (options.mode !== undefined && !['review-safe', 'trusted-local', 'isolated'].includes(options.mode)) {
+  if (options.mode !== undefined && !['review-safe', 'trusted-local', 'restricted-environment'].includes(options.mode)) {
     throw new AdapterError({
       code: ErrorCodes.AK_ADAPTER_STREAM_FAILED,
-      message: 'CLI mode must be review-safe, trusted-local, or isolated',
+    message: 'CLI mode must be review-safe, trusted-local, or restricted-environment',
     })
   }
   if (!options.command.trim()) throw new AdapterError({
@@ -302,7 +302,9 @@ export async function diagnoseCliProvider(
     const decoder = new TextDecoder()
     let output = ''
     writeCliInput(handle)
-    for await (const chunk of handle.child.stdout as AsyncIterable<Buffer>) output += decoder.decode(chunk, { stream: true })
+    for await (const chunk of readCliStdout(handle, new AbortController().signal, options.maxOutputBytes ?? 64 * 1024)) {
+      output += decoder.decode(chunk, { stream: true })
+    }
     output += decoder.decode()
     const result = await handle.completion
     if (result.code !== 0 || result.termination) return {

--- a/packages/adapters/src/cli/types.ts
+++ b/packages/adapters/src/cli/types.ts
@@ -5,7 +5,7 @@ import type {
   TokenUsage,
 } from '@agentskit/core'
 
-export type CliSecurityMode = 'review-safe' | 'trusted-local' | 'isolated'
+export type CliSecurityMode = 'review-safe' | 'trusted-local' | 'restricted-environment'
 export type CliProtocol = 'exec-text' | 'exec-json' | 'acp'
 export type CliTerminationReason = 'aborted' | 'timeout' | 'output-limit'
 
@@ -44,7 +44,7 @@ export interface CliProcessOptions {
   buildArgs?: (request: AdapterRequest) => readonly string[]
   /** Working directory exposed to the child process. */
   cwd?: string
-  /** Safe by default; trusted-local may inherit the developer environment. */
+  /** Safe by default; trusted-local may inherit the developer environment. The restricted mode is not an OS sandbox. */
   mode?: CliSecurityMode
   /** Explicit environment overlay. Values are redacted from diagnostics. */
   env?: Readonly<Record<string, string | undefined>>

--- a/packages/adapters/src/createAdapter.ts
+++ b/packages/adapters/src/createAdapter.ts
@@ -91,6 +91,10 @@ export function createAdapter(config: CreateAdapterConfig): AdapterFactory {
             activeStream = null
           } catch (err) {
             if (isAbortError(err) || controller.signal.aborted) return
+            // Parser failures must release the response and iterator before the
+            // terminal error is exposed; otherwise a failed stream can retain
+            // a socket/body until the provider times out.
+            cleanup()
             const message = err instanceof Error ? err.message : String(err)
             yield adapterErrorChunk(message, { cause: err })
           } finally {

--- a/packages/adapters/src/openai.ts
+++ b/packages/adapters/src/openai.ts
@@ -1,4 +1,4 @@
-import type { AdapterFactory, AdapterRequest, StreamSource } from '@agentskit/core'
+import type { AdapterCapabilities, AdapterFactory, AdapterRequest, StreamSource } from '@agentskit/core'
 import { parseOpenAIStream, toProviderMessages, type RetryOptions } from './utils'
 import { createStreamSource } from './stream-source'
 
@@ -15,6 +15,8 @@ export interface OpenAIConfig {
    * Turn this on for vanilla `api.openai.com`.
    */
   includeUsage?: boolean
+  /** Explicit capability facts for OpenAI-compatible providers with custom models. */
+  capabilities?: Partial<AdapterCapabilities>
 }
 
 export function openai(config: OpenAIConfig): AdapterFactory {
@@ -40,12 +42,13 @@ export function openai(config: OpenAIConfig): AdapterFactory {
   return {
     capabilities: {
       streaming: true,
-      tools: true,
+      tools: config.capabilities?.tools ?? true,
       // o1 / o3 models emit reasoning; older models don't. Accurate per-model
       // detection would need a model registry; 'true' is the safer default here.
-      reasoning: model.startsWith('o1') || model.startsWith('o3'),
-      multiModal: model.startsWith('gpt-4') || model.startsWith('o'),
+      reasoning: config.capabilities?.reasoning ?? (model.startsWith('o1') || model.startsWith('o3')),
+      multiModal: config.capabilities?.multiModal ?? (model.startsWith('gpt-4') || model.startsWith('o')),
       usage: true,
+      ...config.capabilities,
     },
     createSource: (request: AdapterRequest): StreamSource => {
       const body: Record<string, unknown> = {

--- a/packages/adapters/src/utils.ts
+++ b/packages/adapters/src/utils.ts
@@ -396,12 +396,12 @@ function computeDelay(attempt: number, opts: Required<Pick<RetryOptions, 'baseDe
   return Math.floor(Math.random() * exp)
 }
 
-function parseRetryAfter(value: string | null): number | undefined {
+function parseRetryAfter(value: string | null, maxDelayMs: number): number | undefined {
   if (!value) return undefined
   const n = Number(value)
-  if (!Number.isNaN(n)) return n * 1000
+  if (Number.isFinite(n) && n >= 0) return Math.min(n * 1000, maxDelayMs)
   const date = Date.parse(value)
-  if (!Number.isNaN(date)) return Math.max(0, date - Date.now())
+  if (!Number.isNaN(date)) return Math.min(maxDelayMs, Math.max(0, date - Date.now()))
   return undefined
 }
 
@@ -434,7 +434,7 @@ export async function fetchWithRetry(
         return response
       }
 
-      const retryAfterMs = parseRetryAfter(response.headers.get('retry-after'))
+      const retryAfterMs = parseRetryAfter(response.headers.get('retry-after'), opts.maxDelayMs)
       const delay = retryAfterMs ?? computeDelay(attempt, opts)
       retryOpt.onRetry?.({ attempt, delayMs: delay, reason: `HTTP ${response.status}` })
       // Drain the body so the connection can be reused / does not leak.

--- a/packages/adapters/tests/cli.test.ts
+++ b/packages/adapters/tests/cli.test.ts
@@ -190,6 +190,17 @@ describe('CLI adapters', () => {
     expect(diagnostic.elapsedMs).toEqual(expect.any(Number))
   })
 
+  it('bounds diagnostic stdout', async () => {
+    const diagnostic = await diagnoseCliProvider({
+      command: process.execPath,
+      diagnosticArgs: ['-e', "process.stdout.write('x'.repeat(1000))"],
+      maxOutputBytes: 32,
+      providerId: 'fixture',
+    })
+    expect(diagnostic.available).toBe(false)
+    expect(diagnostic.error).toMatch(/output exceeded|output-limit|failed/)
+  })
+
   it('exposes validated first-party manifests without auto-discovery', () => {
     const manifests = listCliProviderManifests()
     expect(manifests.map(manifest => manifest.id)).toEqual(['codex', 'claude-code', 'grok', 'opencode'])

--- a/packages/adapters/tests/retry.test.ts
+++ b/packages/adapters/tests/retry.test.ts
@@ -71,6 +71,18 @@ describe('fetchWithRetry', () => {
     expect(res.status).toBe(200)
   })
 
+  it('does not turn invalid Retry-After values into unbounded delays', async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce(fakeResponse(429, '', { 'retry-after': 'Infinity' }))
+      .mockResolvedValueOnce(fakeResponse(200, 'ok'))
+    const sleep = vi.fn().mockResolvedValue(undefined)
+
+    await fetchWithRetry(fn, new AbortController().signal, { sleep, jitter: false })
+
+    expect(sleep).toHaveBeenCalledWith(500)
+  })
+
   it('uses exponential backoff when jitter is off', async () => {
     const fn = vi
       .fn()

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -134,7 +134,7 @@ console.log('@agentskit/cli loaded')
 ## Maturity and compatibility
 
 - Stability: **beta** — see [docs/STABILITY.md](../../docs/STABILITY.md)
-- **Node.js 22+** and **TypeScript** strict mode
+- **Node.js 20+** and **TypeScript** strict mode
 - Published as `@agentskit/cli`
 
 ## Contributing

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -134,7 +134,7 @@ console.log('@agentskit/cli loaded')
 ## Maturity and compatibility
 
 - Stability: **beta** — see [docs/STABILITY.md](../../docs/STABILITY.md)
-- **Node.js 20+** and **TypeScript** strict mode
+- **Node.js 22+** and **TypeScript** strict mode
 - Published as `@agentskit/cli`
 
 ## Contributing

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,9 @@
   "name": "@agentskit/cli",
   "version": "0.13.38",
   "description": "CLI for AgentsKit chat and project scaffolding.",
+  "engines": {
+    "node": ">=22"
+  },
   "keywords": [
     "agentskit",
     "ai",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,6 +65,7 @@
     "kleur": "^4.1.5",
     "localtunnel": "^2.0.2",
     "react": "^19.2.8",
+    "tsx": "^4.23.5",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/packages/cli/src/app/ChatApp.tsx
+++ b/packages/cli/src/app/ChatApp.tsx
@@ -26,6 +26,7 @@ import { useToolPermissions } from '../runtime/use-tool-permissions'
 import { useSessionMeta } from '../runtime/use-session-meta'
 import { HookDispatcher } from '../extensibility/hooks'
 import type { HookHandler } from '../extensibility/plugins'
+import { applyPolicyToTools } from '../extensibility/permissions'
 import { useEffect } from 'react'
 
 export interface ChatCommandOptions {
@@ -92,8 +93,11 @@ export function ChatApp(options: ChatCommandOptions) {
 
   const mergedTools = useMemo(() => {
     const extra = options.extraTools ?? []
-    return [...tools, ...extra]
-  }, [tools, options.extraTools])
+    const combined = [...tools, ...extra]
+    return options.permissionPolicy
+      ? applyPolicyToTools(options.permissionPolicy, combined)
+      : combined
+  }, [tools, options.extraTools, options.permissionPolicy])
 
   const mergedSkills = useMemo(() => {
     const extra = options.extraSkills ?? []

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -34,6 +34,7 @@ export function registerChatCommand(program: Command): void {
       (value: string, prev: string[] = []) => [...prev, value],
       [],
     )
+    .option('--discover-plugins', 'Also auto-discover plugins from ~/.agentskit/plugins')
     .option(
       '--mode <mode>',
       'Permission mode: default | plan | acceptEdits | bypassPermissions',
@@ -74,6 +75,7 @@ export function registerChatCommand(program: Command): void {
       const pluginBundle = await loadPlugins({
         specs: config?.plugins ?? [],
         pluginDirs: (options.pluginDir as string[]) ?? [],
+        autoDiscoverUserDir: Boolean(options.discoverPlugins),
       })
 
       const configHooks = configHooksToHandlers(config?.hooks as ConfigHooksMap | undefined)

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -2,7 +2,7 @@ import { mkdirSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import path from 'node:path'
 import type { Command } from 'commander'
-import { loadConfig } from '../config'
+import { loadConfig, redactConfig } from '../config'
 
 export function registerConfigCommand(program: Command): void {
   program
@@ -24,7 +24,7 @@ export function registerConfigCommand(program: Command): void {
 
       if (action === 'show') {
         const config = await loadConfig()
-        process.stdout.write(JSON.stringify(config ?? {}, null, 2) + '\n')
+        process.stdout.write(JSON.stringify(redactConfig(config ?? {}), null, 2) + '\n')
         return
       }
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander'
+import packageJson from '../../package.json'
 import { registerChatCommand } from './chat'
 import { registerRunCommand } from './run'
 import { registerInitCommand } from './init'
@@ -19,6 +20,7 @@ export function createCli(): Command {
   program
     .name('agentskit')
     .description('AgentsKit CLI for chat demos and project bootstrapping.')
+    .version(packageJson.version)
 
   registerChatCommand(program)
   registerRunCommand(program)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -14,6 +14,7 @@ export function registerInitCommand(program: Command): void {
     .option('--tools <tools>', 'Comma-separated tools (web_search,filesystem,shell)')
     .option('--memory <backend>', 'Memory backend (none|file|sqlite)')
     .option('--pm <packageManager>', 'Package manager (pnpm|npm|yarn|bun)')
+    .option('--force', 'Overwrite generated files in a non-empty target directory')
     .option('-y, --yes', 'Skip interactive prompts; use flag values + defaults')
     .action(async (rawOptions) => {
       const isCi = !process.stdout.isTTY || rawOptions.yes || rawOptions.template
@@ -30,6 +31,7 @@ export function registerInitCommand(program: Command): void {
             : [],
           memory: (rawOptions.memory ?? 'none') as MemoryKind,
           packageManager: (rawOptions.pm ?? 'pnpm') as PackageManager,
+          force: Boolean(rawOptions.force),
         }
       } else {
         const result = await runInteractiveInit({
@@ -39,18 +41,22 @@ export function registerInitCommand(program: Command): void {
         if (result.cancelled) {
           process.exit(0)
         }
-        resolved = result.options
+        resolved = { ...result.options, force: Boolean(rawOptions.force) }
       }
 
-      await writeStarterProject(resolved)
+      const overwritten = (await writeStarterProject(resolved)) ?? []
 
       if (isCi) {
         process.stdout.write(
           `Created ${resolved.template} starter in ${path.relative(process.cwd(), resolved.targetDir) || '.'}\n` +
+            (overwritten.length > 0 ? `Overwritten: ${overwritten.join(', ')}\n` : '') +
             `★ Star AgentsKit (solo-built — it helps a lot): https://github.com/AgentsKit-io/agentskit\n`,
         )
       } else {
         printNextSteps(resolved)
+        if (overwritten.length > 0) {
+          process.stdout.write(`Overwritten: ${overwritten.join(', ')}\n`)
+        }
       }
     })
 }

--- a/packages/cli/src/components/fetch.ts
+++ b/packages/cli/src/components/fetch.ts
@@ -91,7 +91,19 @@ export function resolveAuthHeader(
   const map = config?.registryAuth
   if (!map) return {}
   for (const [registryBase, envVar] of Object.entries(map)) {
-    if (base.startsWith(registryBase)) {
+    let configured: URL
+    let target: URL
+    try {
+      configured = new URL(registryBase)
+      target = new URL(base)
+    } catch {
+      continue
+    }
+    const configuredPath = configured.pathname.replace(/\/+$/, '') || '/'
+    const targetPath = target.pathname.replace(/\/+$/, '') || '/'
+    const samePathBoundary =
+      configuredPath === '/' || targetPath === configuredPath || targetPath.startsWith(`${configuredPath}/`)
+    if (target.origin === configured.origin && samePathBoundary) {
       const token = env[envVar]
       if (token) return { authorization: `Bearer ${token}` }
     }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises'
+import { access, readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { resolve, join } from 'node:path'
 
@@ -75,17 +75,24 @@ async function loadJsonConfig(path: string): Promise<AgentsKitConfig | undefined
   try {
     const raw = await readFile(path, 'utf8')
     return JSON.parse(raw) as AgentsKitConfig
-  } catch {
-    return undefined
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw new Error(`Failed to load JSON config ${path}: ${err instanceof Error ? err.message : String(err)}`)
   }
 }
 
 async function loadTsConfig(path: string): Promise<AgentsKitConfig | undefined> {
   try {
-    const mod = await import(path)
+    await access(path)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw err
+  }
+  try {
+    const mod = await import(`${path}?agentskit_config=${Date.now()}`)
     return (mod.default ?? mod) as AgentsKitConfig
-  } catch {
-    return undefined
+  } catch (err) {
+    throw new Error(`Failed to load TypeScript config ${path}: ${err instanceof Error ? err.message : String(err)}`)
   }
 }
 
@@ -97,8 +104,9 @@ async function loadPackageJsonConfig(dir: string): Promise<AgentsKitConfig | und
       return pkg.agentskit as AgentsKitConfig
     }
     return undefined
-  } catch {
-    return undefined
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw new Error(`Failed to load package.json config ${dir}: ${err instanceof Error ? err.message : String(err)}`)
   }
 }
 
@@ -119,24 +127,23 @@ function mergeConfigs(
   if (!base && !override) return undefined
   if (!base) return override
   if (!override) return base
-  return {
-    ...base,
-    ...override,
-    tools: { ...base.tools, ...override.tools },
-    defaults: { ...base.defaults, ...override.defaults },
-    runtime: { ...base.runtime, ...override.runtime },
-    observability: { ...base.observability, ...override.observability },
+  const merge = (left: unknown, right: unknown): unknown => {
+    if (!left || typeof left !== 'object' || Array.isArray(left)) return right
+    if (!right || typeof right !== 'object' || Array.isArray(right)) return right
+    const out: Record<string, unknown> = { ...(left as Record<string, unknown>) }
+    for (const [key, value] of Object.entries(right as Record<string, unknown>)) {
+      out[key] = key in out ? merge(out[key], value) : value
+    }
+    return out
   }
+  return merge(base, override) as AgentsKitConfig
 }
 
 async function loadLocalConfig(cwd: string): Promise<AgentsKitConfig | undefined> {
   const tsConfig = await loadTsConfig(join(cwd, '.agentskit.config.ts'))
-  if (tsConfig) return tsConfig
-
   const jsonConfig = await loadJsonConfig(join(cwd, '.agentskit.config.json'))
-  if (jsonConfig) return jsonConfig
-
-  return await loadPackageJsonConfig(cwd)
+  const packageConfig = await loadPackageJsonConfig(cwd)
+  return mergeConfigs(mergeConfigs(packageConfig, jsonConfig), tsConfig)
 }
 
 async function loadGlobalConfig(home: string | null | undefined): Promise<AgentsKitConfig | undefined> {
@@ -163,4 +170,18 @@ export async function loadConfig(options?: LoadConfigOptions): Promise<AgentsKit
   const global = await loadGlobalConfig(options?.home)
   const local = await loadLocalConfig(cwd)
   return mergeConfigs(global, local)
+}
+
+const SECRET_KEY = /^(api[-_]?key|token|secret|password|authorization|private[-_]?key)$/i
+
+/** Return a display-safe copy; secrets are never printed by default. */
+export function redactConfig(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactConfig)
+  if (!value || typeof value !== 'object') return value
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, child]) => [
+      key,
+      SECRET_KEY.test(key) ? '[REDACTED]' : redactConfig(child),
+    ]),
+  )
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -173,6 +173,11 @@ export async function loadConfig(options?: LoadConfigOptions): Promise<AgentsKit
 }
 
 const SECRET_KEY = /^(api[-_]?key|token|secret|password|authorization|private[-_]?key)$/i
+const SECRET_ENV_KEY = /(?:^|_)(?:api_?key|token|secret|password|authorization|private_?key)$/i
+
+function isSecretKey(key: string): boolean {
+  return SECRET_KEY.test(key) || SECRET_ENV_KEY.test(key)
+}
 
 /** Return a display-safe copy; secrets are never printed by default. */
 export function redactConfig(value: unknown): unknown {
@@ -181,7 +186,7 @@ export function redactConfig(value: unknown): unknown {
   return Object.fromEntries(
     Object.entries(value as Record<string, unknown>).map(([key, child]) => [
       key,
-      SECRET_KEY.test(key) ? '[REDACTED]' : redactConfig(child),
+      isSecretKey(key) ? '[REDACTED]' : redactConfig(child),
     ]),
   )
 }

--- a/packages/cli/src/dev.ts
+++ b/packages/cli/src/dev.ts
@@ -1,8 +1,19 @@
 import { spawn, type ChildProcess } from 'node:child_process'
+import { createRequire } from 'node:module'
 import { resolve as pathResolve, basename } from 'node:path'
 import { existsSync } from 'node:fs'
 import chokidar from 'chokidar'
 import kleur from 'kleur'
+
+const require = createRequire(import.meta.url)
+
+function resolveTsxCli(): string {
+  try {
+    return require.resolve('tsx/cli')
+  } catch {
+    throw new Error('TypeScript execution requires the packaged tsx dependency')
+  }
+}
 
 export interface DevOptions {
   /** Entry file to run (relative or absolute). */
@@ -80,8 +91,10 @@ export function startDev(options: DevOptions): DevController {
   const debounceMs = options.debounceMs ?? 200
 
   const isTs = entry.endsWith('.ts') || entry.endsWith('.tsx')
-  const cmd = isTs ? 'tsx' : 'node'
-  const baseArgs = [entry, ...(options.scriptArgs ?? [])]
+  const cmd = isTs ? process.execPath : 'node'
+  const baseArgs = isTs
+    ? [resolveTsxCli(), entry, ...(options.scriptArgs ?? [])]
+    : [entry, ...(options.scriptArgs ?? [])]
 
   const spawnFn =
     options.spawn ??

--- a/packages/cli/src/dev.ts
+++ b/packages/cli/src/dev.ts
@@ -102,7 +102,9 @@ export function startDev(options: DevOptions): DevController {
   let child: ChildProcess | undefined
   let restartCount = 0
   let restartTimer: NodeJS.Timeout | undefined
+  let delayedStartTimer: NodeJS.Timeout | undefined
   let stopped = false
+  let stdinListener: ((data: Buffer) => void) | undefined
   let resolveDone: () => void
   const done = new Promise<void>(r => { resolveDone = r })
 
@@ -139,7 +141,10 @@ export function startDev(options: DevOptions): DevController {
         child.kill('SIGTERM')
       }
       // Brief pause so the SIGTERM is delivered before we spawn again.
-      setTimeout(startChild, 80)
+      delayedStartTimer = setTimeout(() => {
+        delayedStartTimer = undefined
+        if (!stopped) startChild()
+      }, 80)
     }, debounceMs)
   }
 
@@ -153,6 +158,9 @@ export function startDev(options: DevOptions): DevController {
     if (stopped) return
     stopped = true
     if (restartTimer) clearTimeout(restartTimer)
+    if (delayedStartTimer) clearTimeout(delayedStartTimer)
+    if (stdinListener) process.stdin.off('data', stdinListener)
+    if (process.stdin.isTTY && process.stdin.setRawMode) process.stdin.setRawMode(false)
     if (child && !child.killed && child.exitCode === null) {
       child.kill('SIGTERM')
     }
@@ -165,11 +173,12 @@ export function startDev(options: DevOptions): DevController {
   if (process.stdin.isTTY && process.stdin.setRawMode) {
     process.stdin.setRawMode(true)
     process.stdin.resume()
-    process.stdin.on('data', (data: Buffer) => {
+    stdinListener = (data: Buffer) => {
       const key = data.toString()
       if (key === 'r') restart('manual')
       if (key === 'q' || key === '\u0003') void stop()
-    })
+    }
+    process.stdin.on('data', stdinListener)
   }
 
   return {

--- a/packages/cli/src/extensibility/hooks/runner.ts
+++ b/packages/cli/src/extensibility/hooks/runner.ts
@@ -15,7 +15,7 @@ export interface HookDispatchResult {
  *   - `modify`:   replace the payload for subsequent handlers
  *   - `block`:    stop dispatch and surface a reason to the caller
  *
- * Handlers that throw are reported via `onError` and treated as `continue`.
+ * Handler failures block by default so enforcement hooks cannot fail open.
  */
 export class HookDispatcher {
   private readonly handlers = new Map<HookEvent, HookHandler[]>()
@@ -48,7 +48,7 @@ export class HookDispatcher {
         result = await handler.run(current)
       } catch (err) {
         this.onError(handler, err)
-        continue
+        return { payload: current, blocked: true, reason: 'hook failed' }
       }
 
       if (result.decision === 'block') {

--- a/packages/cli/src/extensibility/hooks/shell-hooks.ts
+++ b/packages/cli/src/extensibility/hooks/shell-hooks.ts
@@ -1,6 +1,8 @@
 import { spawn } from 'node:child_process'
 import type { HookEvent, HookHandler, HookPayload, HookResult } from '../plugins/types'
 
+const MAX_HOOK_STDOUT_BYTES = 64 * 1024
+
 export interface ConfigHookEntry {
   /** Command to run. Executed through `sh -c`, so shell syntax is allowed. */
   run: string
@@ -54,8 +56,20 @@ function runShellHook(entry: ConfigHookEntry, payload: HookPayload): Promise<Hoo
     })
 
     let stdout = ''
+    let stdoutBytes = 0
     child.stdout.on('data', (chunk) => {
-      stdout += chunk.toString()
+      const text = chunk.toString()
+      const bytes = Buffer.byteLength(text)
+      if (stdoutBytes + bytes > MAX_HOOK_STDOUT_BYTES) {
+        if (child.pid !== undefined) {
+          try { process.kill(-child.pid, 'SIGKILL') } catch { /* group may already be gone */ }
+        }
+        try { child.kill('SIGKILL') } catch { /* ignore */ }
+        settle({ decision: 'block', reason: `shell hook output exceeded ${MAX_HOOK_STDOUT_BYTES} bytes` })
+        return
+      }
+      stdoutBytes += bytes
+      stdout += text
     })
 
     const timer = setTimeout(() => {

--- a/packages/cli/src/extensibility/hooks/shell-hooks.ts
+++ b/packages/cli/src/extensibility/hooks/shell-hooks.ts
@@ -85,10 +85,14 @@ function runShellHook(entry: ConfigHookEntry, payload: HookPayload): Promise<Hoo
       }
       try {
         const parsed = JSON.parse(trimmed) as HookResult
-        settle(parsed)
+        if (!parsed || typeof parsed !== 'object' || !('decision' in parsed) ||
+            !['continue', 'block', 'modify'].includes(String(parsed.decision))) {
+          settle({ decision: 'block', reason: 'shell hook returned an invalid decision' })
+        } else {
+          settle(parsed)
+        }
       } catch {
-        // Hook printed non-JSON output; treat as continue.
-        settle({ decision: 'continue' })
+        settle({ decision: 'block', reason: 'shell hook returned invalid JSON' })
       }
     })
 

--- a/packages/cli/src/extensibility/mcp/client.ts
+++ b/packages/cli/src/extensibility/mcp/client.ts
@@ -1,6 +1,9 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import type { McpServerSpec } from '../plugins/types'
 
+const MAX_FRAME_BYTES = 1024 * 1024
+const DISPOSE_GRACE_MS = 1000
+
 export interface McpTool {
   name: string
   description?: string
@@ -42,6 +45,7 @@ export class McpClient {
     const child = spawn(this.spec.command, this.spec.args ?? [], {
       env: { ...process.env, ...(this.spec.env ?? {}) },
       stdio: ['pipe', 'pipe', 'pipe'],
+      detached: process.platform !== 'win32',
     }) as ChildProcessWithoutNullStreams
     this.child = child
 
@@ -78,7 +82,23 @@ export class McpClient {
   dispose(): void {
     if (this.disposed) return
     this.disposed = true
-    this.child?.kill('SIGTERM')
+    for (const pending of this.pending.values()) {
+      pending({ jsonrpc: '2.0', id: 0, error: { code: -32800, message: 'client disposed' } })
+    }
+    this.pending.clear()
+    const child = this.child
+    if (!child || child.killed) return
+    const kill = (signal: NodeJS.Signals): void => {
+      try {
+        if (process.platform !== 'win32' && child.pid) process.kill(-child.pid, signal)
+        else child.kill(signal)
+      } catch {
+        // The process may have exited between the graceful and forced kill.
+      }
+    }
+    kill('SIGTERM')
+    const timer = setTimeout(() => kill('SIGKILL'), DISPOSE_GRACE_MS)
+    timer.unref()
   }
 
   private request(method: string, params: unknown): Promise<unknown> {
@@ -110,10 +130,20 @@ export class McpClient {
 
   private onStdout(chunk: string): void {
     this.buffer += chunk
+    if (Buffer.byteLength(this.buffer, 'utf8') > MAX_FRAME_BYTES && !this.buffer.includes('\n')) {
+      this.onError(new Error(`mcp ${this.spec.name} frame exceeded ${MAX_FRAME_BYTES} bytes`))
+      this.dispose()
+      return
+    }
     let newlineIndex = this.buffer.indexOf('\n')
     while (newlineIndex !== -1) {
       const line = this.buffer.slice(0, newlineIndex).trim()
       this.buffer = this.buffer.slice(newlineIndex + 1)
+      if (Buffer.byteLength(line, 'utf8') > MAX_FRAME_BYTES) {
+        this.onError(new Error(`mcp ${this.spec.name} frame exceeded ${MAX_FRAME_BYTES} bytes`))
+        this.dispose()
+        return
+      }
       if (line) {
         try {
           const parsed = JSON.parse(line) as JsonRpcResponse

--- a/packages/cli/src/extensibility/plugins/loader.ts
+++ b/packages/cli/src/extensibility/plugins/loader.ts
@@ -12,8 +12,8 @@ export interface LoadPluginsOptions {
   /** Working directory; defaults to process.cwd(). */
   cwd?: string
   /**
-   * Auto-discover from `~/.agentskit/plugins`. Defaults to true. Tests pass
-   * false so the user's real home dir can't contaminate runs.
+   * Auto-discover from `~/.agentskit/plugins`. Defaults to false because
+   * discovery executes arbitrary third-party code.
    */
   autoDiscoverUserDir?: boolean
   /** Error logger. Defaults to stderr. */
@@ -33,7 +33,7 @@ export async function loadPlugins(options: LoadPluginsOptions = {}): Promise<Plu
     specs = [],
     pluginDirs = [],
     cwd = process.cwd(),
-    autoDiscoverUserDir = true,
+    autoDiscoverUserDir = false,
     onError = (spec, err) =>
       process.stderr.write(
         `[agentskit] plugin "${spec}" failed to load: ${err instanceof Error ? err.message : String(err)}\n`,

--- a/packages/cli/src/init-writer.ts
+++ b/packages/cli/src/init-writer.ts
@@ -1,0 +1,60 @@
+import { lstat, mkdir, mkdtemp, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import path from 'node:path'
+import type { InitCommandOptions, StarterKind, ToolKind, MemoryKind, PackageManager } from './init'
+import type { Provider } from './init-providers'
+
+type RenderContext = { template: StarterKind; provider: Provider; tools: ToolKind[]; memory: MemoryKind; pm: PackageManager }
+type TemplateRenderer = (ctx: RenderContext) => Record<string, string>
+
+const PACKAGE_RANGES: Record<string, string> = {
+  '@agentskit/adapters': '^0.15.2', '@agentskit/angular': '^0.5.3', '@agentskit/ink': '^0.10.9',
+  '@agentskit/memory': '^0.11.8', '@agentskit/react': '^0.8.3', '@agentskit/runtime': '^0.10.15',
+  '@agentskit/skills': '^0.9.3', '@agentskit/svelte': '^0.5.3', '@agentskit/tools': '^0.13.6', '@agentskit/vue': '^0.5.3',
+}
+
+function align(files: Record<string, string>): Record<string, string> {
+  const result = { ...files }
+  for (const file of ['package.json', 'deno.json']) {
+    if (!files[file]) continue
+    const parsed = JSON.parse(files[file]!) as Record<string, unknown>
+    const sections = file === 'package.json' ? ['dependencies', 'devDependencies', 'peerDependencies'] : ['imports']
+    for (const sectionName of sections) {
+      const section = parsed[sectionName]
+      if (!section || typeof section !== 'object' || Array.isArray(section)) continue
+      for (const [name, range] of Object.entries(PACKAGE_RANGES)) if (name in section) {
+        (section as Record<string, unknown>)[name] = file === 'deno.json' ? `npm:${name}@${range}` : range
+      }
+    }
+    result[file] = `${JSON.stringify(parsed, null, 2)}\n`
+  }
+  return result
+}
+
+async function existing(filePath: string) {
+  try { return await lstat(filePath) } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw error
+  }
+}
+
+export async function writeStarterProject(options: InitCommandOptions, renderers: Record<StarterKind, TemplateRenderer>): Promise<string[]> {
+  const ctx: RenderContext = { template: options.template, provider: options.provider ?? 'demo', tools: options.tools ?? [], memory: options.memory ?? 'none', pm: options.packageManager ?? 'pnpm' }
+  const files = align(renderers[ctx.template](ctx))
+  await mkdir(options.targetDir, { recursive: true })
+  const target = await lstat(options.targetDir)
+  if (target.isSymbolicLink() || !target.isDirectory()) throw new Error(`Refusing to write starter into non-directory target: ${options.targetDir}`)
+  if ((await readdir(options.targetDir)).length > 0 && !options.force) throw new Error(`Target directory is not empty: ${options.targetDir} (re-run with --force to overwrite generated files)`)
+  const overwritten: string[] = []
+  for (const [relativePath, content] of Object.entries(files)) {
+    const absolutePath = path.join(options.targetDir, relativePath)
+    await mkdir(path.dirname(absolutePath), { recursive: true })
+    const destination = await existing(absolutePath)
+    if (destination?.isSymbolicLink()) throw new Error(`Refusing to overwrite symlink: ${absolutePath}`)
+    if (destination) overwritten.push(relativePath)
+    const tempDir = await mkdtemp(path.join(path.dirname(absolutePath), `.agentskit-init-${randomUUID()}-`))
+    try { await writeFile(path.join(tempDir, path.basename(absolutePath)), content, 'utf8'); await rename(path.join(tempDir, path.basename(absolutePath)), absolutePath) }
+    finally { await rm(tempDir, { recursive: true, force: true }).catch(() => {}) }
+  }
+  return overwritten
+}

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -1,5 +1,6 @@
-import { mkdir, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, mkdtemp, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
+import { randomUUID } from 'node:crypto'
 import {
   PROVIDER_DEFAULT_MODEL,
   PROVIDER_ENV_KEY,
@@ -34,6 +35,8 @@ export interface InitCommandOptions {
   tools?: ToolKind[]
   memory?: MemoryKind
   packageManager?: PackageManager
+  /** Refuse non-empty destinations unless explicitly enabled. */
+  force?: boolean
 }
 
 interface RenderContext {
@@ -1512,7 +1515,49 @@ const TEMPLATE_FN: Record<StarterKind, (ctx: RenderContext) => Record<string, st
   angular: angularStarter,
 }
 
-export async function writeStarterProject(options: InitCommandOptions): Promise<void> {
+// Keep generated projects on the package lines shipped by this release.
+// Update this map as part of the release bump; templates must never silently
+// install the historical 0.4 line.
+const AGENTSKIT_PACKAGE_RANGES: Record<string, string> = {
+  '@agentskit/adapters': '^0.15.2',
+  '@agentskit/angular': '^0.5.3',
+  '@agentskit/ink': '^0.10.9',
+  '@agentskit/memory': '^0.11.8',
+  '@agentskit/react': '^0.8.3',
+  '@agentskit/runtime': '^0.10.15',
+  '@agentskit/skills': '^0.9.3',
+  '@agentskit/svelte': '^0.5.3',
+  '@agentskit/tools': '^0.13.6',
+  '@agentskit/vue': '^0.5.3',
+}
+
+function alignGeneratedPackageVersions(files: Record<string, string>): Record<string, string> {
+  const packageJson = files['package.json']
+  if (!packageJson) return files
+  const parsed = JSON.parse(packageJson) as Record<string, unknown>
+  for (const sectionName of ['dependencies', 'devDependencies', 'peerDependencies', 'imports']) {
+    const section = parsed[sectionName]
+    if (!section || typeof section !== 'object' || Array.isArray(section)) continue
+    for (const [name, range] of Object.entries(AGENTSKIT_PACKAGE_RANGES)) {
+      if (!(name in section)) continue
+      ;(section as Record<string, unknown>)[name] = sectionName === 'imports'
+        ? `npm:${name}@${range}`
+        : range
+    }
+  }
+  return { ...files, 'package.json': `${JSON.stringify(parsed, null, 2)}\n` }
+}
+
+async function lstatOrMissing(filePath: string) {
+  try {
+    return await lstat(filePath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw error
+  }
+}
+
+export async function writeStarterProject(options: InitCommandOptions): Promise<string[]> {
   const ctx: RenderContext = {
     template: options.template,
     provider: options.provider ?? 'demo',
@@ -1521,14 +1566,42 @@ export async function writeStarterProject(options: InitCommandOptions): Promise<
     pm: options.packageManager ?? 'pnpm',
   }
 
-  const files = TEMPLATE_FN[ctx.template](ctx)
+  const files = alignGeneratedPackageVersions(TEMPLATE_FN[ctx.template](ctx))
   await mkdir(options.targetDir, { recursive: true })
 
-  await Promise.all(
-    Object.entries(files).map(async ([relativePath, content]) => {
-      const absolutePath = path.join(options.targetDir, relativePath)
-      await mkdir(path.dirname(absolutePath), { recursive: true })
-      await writeFile(absolutePath, content, 'utf8')
-    }),
-  )
+  const targetStat = await lstat(options.targetDir)
+  if (targetStat.isSymbolicLink() || !targetStat.isDirectory()) {
+    throw new Error(`Refusing to write starter into non-directory target: ${options.targetDir}`)
+  }
+  const existingEntries = await readdir(options.targetDir)
+  if (existingEntries.length > 0 && !options.force) {
+    throw new Error(
+      `Target directory is not empty: ${options.targetDir} (re-run with --force to overwrite generated files)`,
+    )
+  }
+
+  const overwritten: string[] = []
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const absolutePath = path.join(options.targetDir, relativePath)
+    await mkdir(path.dirname(absolutePath), { recursive: true })
+    const destinationStat = await lstatOrMissing(absolutePath)
+    if (destinationStat?.isSymbolicLink()) {
+      throw new Error(`Refusing to overwrite symlink: ${absolutePath}`)
+    }
+    if (destinationStat) overwritten.push(relativePath)
+
+    // Same-directory temp + rename gives atomic replacement for each generated
+    // file while preserving unrelated files in an existing project.
+    const tempDir = await mkdtemp(path.join(path.dirname(absolutePath), `.agentskit-init-${randomUUID()}-`))
+    const tempPath = path.join(tempDir, path.basename(absolutePath))
+    try {
+      await writeFile(tempPath, content, 'utf8')
+      await rename(tempPath, absolutePath)
+    } finally {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {})
+    }
+  }
+
+  return overwritten
 }

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -1,12 +1,11 @@
-import { lstat, mkdir, mkdtemp, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { randomUUID } from 'node:crypto'
 import {
   PROVIDER_DEFAULT_MODEL,
   PROVIDER_ENV_KEY,
   PROVIDER_IMPORT,
 } from './init-providers'
 import type { Provider } from './init-providers'
+import { writeStarterProject as writeProject } from './init-writer'
 
 export type { Provider } from './init-providers'
 
@@ -1515,104 +1514,6 @@ const TEMPLATE_FN: Record<StarterKind, (ctx: RenderContext) => Record<string, st
   angular: angularStarter,
 }
 
-// Keep generated projects on the package lines shipped by this release.
-// Update this map as part of the release bump; templates must never silently
-// install the historical 0.4 line.
-const AGENTSKIT_PACKAGE_RANGES: Record<string, string> = {
-  '@agentskit/adapters': '^0.15.2',
-  '@agentskit/angular': '^0.5.3',
-  '@agentskit/ink': '^0.10.9',
-  '@agentskit/memory': '^0.11.8',
-  '@agentskit/react': '^0.8.3',
-  '@agentskit/runtime': '^0.10.15',
-  '@agentskit/skills': '^0.9.3',
-  '@agentskit/svelte': '^0.5.3',
-  '@agentskit/tools': '^0.13.6',
-  '@agentskit/vue': '^0.5.3',
-}
-
-function alignGeneratedPackageVersions(files: Record<string, string>): Record<string, string> {
-  const packageJson = files['package.json']
-  const denoJson = files['deno.json']
-  const aligned = { ...files }
-  if (packageJson) {
-    const parsed = JSON.parse(packageJson) as Record<string, unknown>
-    for (const sectionName of ['dependencies', 'devDependencies', 'peerDependencies']) {
-      const section = parsed[sectionName]
-      if (!section || typeof section !== 'object' || Array.isArray(section)) continue
-      for (const [name, range] of Object.entries(AGENTSKIT_PACKAGE_RANGES)) {
-        if (name in section) (section as Record<string, unknown>)[name] = range
-      }
-    }
-    aligned['package.json'] = `${JSON.stringify(parsed, null, 2)}\n`
-  }
-  if (denoJson) {
-    const parsed = JSON.parse(denoJson) as Record<string, unknown>
-    const imports = parsed.imports
-    if (imports && typeof imports === 'object' && !Array.isArray(imports)) {
-      for (const [name, range] of Object.entries(AGENTSKIT_PACKAGE_RANGES)) {
-        if (name in imports) (imports as Record<string, unknown>)[name] = `npm:${name}@${range}`
-      }
-    }
-    aligned['deno.json'] = `${JSON.stringify(parsed, null, 2)}\n`
-  }
-  return aligned
-}
-
-async function lstatOrMissing(filePath: string) {
-  try {
-    return await lstat(filePath)
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
-    throw error
-  }
-}
-
 export async function writeStarterProject(options: InitCommandOptions): Promise<string[]> {
-  const ctx: RenderContext = {
-    template: options.template,
-    provider: options.provider ?? 'demo',
-    tools: options.tools ?? [],
-    memory: options.memory ?? 'none',
-    pm: options.packageManager ?? 'pnpm',
-  }
-
-  const files = alignGeneratedPackageVersions(TEMPLATE_FN[ctx.template](ctx))
-  await mkdir(options.targetDir, { recursive: true })
-
-  const targetStat = await lstat(options.targetDir)
-  if (targetStat.isSymbolicLink() || !targetStat.isDirectory()) {
-    throw new Error(`Refusing to write starter into non-directory target: ${options.targetDir}`)
-  }
-  const existingEntries = await readdir(options.targetDir)
-  if (existingEntries.length > 0 && !options.force) {
-    throw new Error(
-      `Target directory is not empty: ${options.targetDir} (re-run with --force to overwrite generated files)`,
-    )
-  }
-
-  const overwritten: string[] = []
-
-  for (const [relativePath, content] of Object.entries(files)) {
-    const absolutePath = path.join(options.targetDir, relativePath)
-    await mkdir(path.dirname(absolutePath), { recursive: true })
-    const destinationStat = await lstatOrMissing(absolutePath)
-    if (destinationStat?.isSymbolicLink()) {
-      throw new Error(`Refusing to overwrite symlink: ${absolutePath}`)
-    }
-    if (destinationStat) overwritten.push(relativePath)
-
-    // Same-directory temp + rename gives atomic replacement for each generated
-    // file while preserving unrelated files in an existing project.
-    const tempDir = await mkdtemp(path.join(path.dirname(absolutePath), `.agentskit-init-${randomUUID()}-`))
-    const tempPath = path.join(tempDir, path.basename(absolutePath))
-    try {
-      await writeFile(tempPath, content, 'utf8')
-      await rename(tempPath, absolutePath)
-    } finally {
-      await rm(tempDir, { recursive: true, force: true }).catch(() => {})
-    }
-  }
-
-  return overwritten
+  return writeProject(options, TEMPLATE_FN)
 }

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -1533,19 +1533,30 @@ const AGENTSKIT_PACKAGE_RANGES: Record<string, string> = {
 
 function alignGeneratedPackageVersions(files: Record<string, string>): Record<string, string> {
   const packageJson = files['package.json']
-  if (!packageJson) return files
-  const parsed = JSON.parse(packageJson) as Record<string, unknown>
-  for (const sectionName of ['dependencies', 'devDependencies', 'peerDependencies', 'imports']) {
-    const section = parsed[sectionName]
-    if (!section || typeof section !== 'object' || Array.isArray(section)) continue
-    for (const [name, range] of Object.entries(AGENTSKIT_PACKAGE_RANGES)) {
-      if (!(name in section)) continue
-      ;(section as Record<string, unknown>)[name] = sectionName === 'imports'
-        ? `npm:${name}@${range}`
-        : range
+  const denoJson = files['deno.json']
+  const aligned = { ...files }
+  if (packageJson) {
+    const parsed = JSON.parse(packageJson) as Record<string, unknown>
+    for (const sectionName of ['dependencies', 'devDependencies', 'peerDependencies']) {
+      const section = parsed[sectionName]
+      if (!section || typeof section !== 'object' || Array.isArray(section)) continue
+      for (const [name, range] of Object.entries(AGENTSKIT_PACKAGE_RANGES)) {
+        if (name in section) (section as Record<string, unknown>)[name] = range
+      }
     }
+    aligned['package.json'] = `${JSON.stringify(parsed, null, 2)}\n`
   }
-  return { ...files, 'package.json': `${JSON.stringify(parsed, null, 2)}\n` }
+  if (denoJson) {
+    const parsed = JSON.parse(denoJson) as Record<string, unknown>
+    const imports = parsed.imports
+    if (imports && typeof imports === 'object' && !Array.isArray(imports)) {
+      for (const [name, range] of Object.entries(AGENTSKIT_PACKAGE_RANGES)) {
+        if (name in imports) (imports as Record<string, unknown>)[name] = `npm:${name}@${range}`
+      }
+    }
+    aligned['deno.json'] = `${JSON.stringify(parsed, null, 2)}\n`
+  }
+  return aligned
 }
 
 async function lstatOrMissing(filePath: string) {

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -5,7 +5,7 @@
  *   1. Hosted index   — https://registry.agentskit.io/r/<id>.json (meta + inlined sources)
  *   2. Raw GitHub      — the registry repo's registry/<id>/ files (works before hosting is live)
  */
-import { mkdir, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, writeFile } from 'node:fs/promises'
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 const RAW_BASE = 'https://raw.githubusercontent.com/AgentsKit-io/agentskit-registry/main'
@@ -35,6 +35,36 @@ function assertInside(parent: string, child: string): void {
   const rel = relative(resolve(parent), resolve(child))
   if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
     throw new Error(`Registry destination escapes target directory: ${child}`)
+  }
+}
+
+async function assertNoSymlinkAncestors(targetDir: string, baseDir: string): Promise<void> {
+  for (const path of [targetDir, baseDir]) {
+    try {
+      if ((await lstat(resolve(path))).isSymbolicLink()) {
+        throw new Error(`Registry destination contains a symlink ancestor: ${resolve(path)}`)
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    }
+  }
+
+  // If the selected base does not exist yet, inspect only its missing-path
+  // ancestors until the first existing directory. Do not walk system parents
+  // of an already-existing user-selected base (for example /var on macOS).
+  let current = resolve(baseDir)
+  while (true) {
+    try {
+      if ((await lstat(current)).isSymbolicLink()) {
+        throw new Error(`Registry destination contains a symlink ancestor: ${current}`)
+      }
+      return
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    }
+    const parent = dirname(current)
+    if (parent === current) return
+    current = parent
   }
 }
 
@@ -192,6 +222,7 @@ export async function addAgent(id: string, options: AddOptions = {}): Promise<Ad
   const baseDir = options.outDir ?? 'agents'
   const targetDir = join(baseDir, id)
   assertInside(baseDir, targetDir)
+  await assertNoSymlinkAncestors(targetDir, baseDir)
   const exists = options.existsImpl ?? defaultExists
   const write =
     options.writeFileImpl ??

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -6,12 +6,53 @@
  *   2. Raw GitHub      — the registry repo's registry/<id>/ files (works before hosting is live)
  */
 import { mkdir, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 const RAW_BASE = 'https://raw.githubusercontent.com/AgentsKit-io/agentskit-registry/main'
 // The committed, prebuilt index (fast path) — served straight from the repo, no
 // separate deploy. Falls back to walking the agent source below.
 const HOSTED_BASE = `${RAW_BASE}/public/r`
+const FETCH_TIMEOUT_MS = 15_000
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+const MAX_AGENT_FILES = 100
+const SAFE_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+function assertSafeId(id: string): void {
+  if (!SAFE_ID.test(id)) throw new Error(`Invalid registry agent id: ${JSON.stringify(id)}`)
+}
+
+function assertSafeRelativePath(filePath: string): void {
+  if (!filePath || isAbsolute(filePath) || filePath.includes('\0')) {
+    throw new Error(`Invalid registry file path: ${JSON.stringify(filePath)}`)
+  }
+  const normalized = filePath.replace(/\\/g, '/')
+  if (normalized.split('/').some(part => part === '..' || part === '')) {
+    throw new Error(`Registry file path must stay relative: ${JSON.stringify(filePath)}`)
+  }
+}
+
+function assertInside(parent: string, child: string): void {
+  const rel = relative(resolve(parent), resolve(child))
+  if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    throw new Error(`Registry destination escapes target directory: ${child}`)
+  }
+}
+
+async function fetchWithLimits(url: string, fetchImpl: typeof fetch): Promise<Response> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    const response = await fetchImpl(url, { signal: controller.signal })
+    if (!response.ok) throw new Error(`${response.status} ${response.statusText}`)
+    const body = await response.arrayBuffer()
+    if (body.byteLength > MAX_RESPONSE_BYTES) {
+      throw new Error(`Registry response exceeded ${MAX_RESPONSE_BYTES} bytes`)
+    }
+    return new Response(body, { status: response.status, headers: response.headers })
+  } finally {
+    clearTimeout(timer)
+  }
+}
 
 export interface RegistryEnvVar {
   name: string
@@ -52,19 +93,18 @@ export interface FetchOptions {
 }
 
 async function getJson(url: string, fetchImpl: typeof fetch): Promise<unknown> {
-  const res = await fetchImpl(url)
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-  return res.json()
+  const res = await fetchWithLimits(url, fetchImpl)
+  return JSON.parse(await res.text())
 }
 
 async function getText(url: string, fetchImpl: typeof fetch): Promise<string> {
-  const res = await fetchImpl(url)
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+  const res = await fetchWithLimits(url, fetchImpl)
   return res.text()
 }
 
 /** Fetch an agent descriptor with inlined file sources, hosted first then raw GitHub. */
 export async function fetchAgent(id: string, options: FetchOptions = {}): Promise<RegistryAgent> {
+  assertSafeId(id)
   const fetchImpl = options.fetchImpl ?? globalThis.fetch
   try {
     const hosted = (await getJson(`${HOSTED_BASE}/${id}.json`, fetchImpl)) as RegistryAgent
@@ -76,6 +116,10 @@ export async function fetchAgent(id: string, options: FetchOptions = {}): Promis
       RegistryAgent,
       'sources'
     >
+    if (!Array.isArray(meta.files) || meta.files.length > MAX_AGENT_FILES) {
+      throw new Error(`Registry agent contains too many files (maximum ${MAX_AGENT_FILES})`)
+    }
+    for (const rel of meta.files) assertSafeRelativePath(rel)
     const sources = await Promise.all(
       meta.files.map(async (rel) => ({
         path: rel,
@@ -147,6 +191,7 @@ export async function addAgent(id: string, options: AddOptions = {}): Promise<Ad
   assertInstallable(agent)
   const baseDir = options.outDir ?? 'agents'
   const targetDir = join(baseDir, id)
+  assertInside(baseDir, targetDir)
   const exists = options.existsImpl ?? defaultExists
   const write =
     options.writeFileImpl ??
@@ -156,11 +201,18 @@ export async function addAgent(id: string, options: AddOptions = {}): Promise<Ad
     })
 
   const written: string[] = []
+  // Validate and check every destination before writing any file, so a later
+  // conflict cannot leave a partially installed agent behind.
   for (const file of agent.sources) {
+    assertSafeRelativePath(file.path)
     const dest = join(targetDir, file.path)
+    assertInside(targetDir, dest)
     if (!options.force && (await exists(dest))) {
       throw new Error(`${dest} already exists (re-run with --force to overwrite)`)
     }
+  }
+  for (const file of agent.sources) {
+    const dest = join(targetDir, file.path)
     await write(dest, file.content)
     written.push(dest)
   }

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -43,8 +43,7 @@ function formatEvent(event: AgentEvent): string {
 
 export async function runAgent(task: string, options: RunCommandOptions): Promise<void> {
   if (options.skill && options.skills) {
-    process.stderr.write('Error: --skill and --skills are mutually exclusive. Use one or the other.\n')
-    process.exit(1)
+    throw new Error('--skill and --skills are mutually exclusive. Use one or the other.')
   }
 
   const { adapter } = resolveChatProvider({

--- a/packages/cli/src/sessions.ts
+++ b/packages/cli/src/sessions.ts
@@ -5,6 +5,7 @@ import {
   readFileSync,
   readdirSync,
   statSync,
+  chmodSync,
   writeFileSync,
 } from 'node:fs'
 import { homedir } from 'node:os'
@@ -42,7 +43,8 @@ function dirFor(cwd: string = process.cwd()): string {
 }
 
 function ensureDir(dir: string): void {
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
+  chmodSync(dir, 0o700)
 }
 
 /** Generate a new session id — ISO-ish timestamp + 6 random hex chars. */
@@ -73,7 +75,9 @@ function readMeta(id: string, cwd: string = process.cwd()): SessionMetadata | nu
 
 export function writeSessionMeta(meta: SessionMetadata, cwd: string = process.cwd()): void {
   ensureDir(dirFor(cwd))
-  writeFileSync(metaPath(meta.id, cwd), JSON.stringify(meta, null, 2))
+  const path = metaPath(meta.id, cwd)
+  writeFileSync(path, JSON.stringify(meta, null, 2), { mode: 0o600 })
+  chmodSync(path, 0o600)
 }
 
 /** Derive a short preview (first user message, one line, max 80 chars). */

--- a/packages/cli/src/tunnel.ts
+++ b/packages/cli/src/tunnel.ts
@@ -64,6 +64,7 @@ export async function startTunnel(options: TunnelOptions): Promise<TunnelControl
 
   let requests = 0
   let stopped = false
+  let signalHandler: (() => void) | undefined
   let resolveDone: () => void
   const done = new Promise<void>(r => { resolveDone = r })
 
@@ -73,6 +74,7 @@ export async function startTunnel(options: TunnelOptions): Promise<TunnelControl
 
   tunnel.on('close', () => {
     if (stopped) return
+    if (signalHandler) process.off('SIGINT', signalHandler)
     banner(`tunnel closed by remote`, 'yellow')
     resolveDone()
   })
@@ -80,6 +82,7 @@ export async function startTunnel(options: TunnelOptions): Promise<TunnelControl
   tunnel.on('error', (...args: unknown[]) => {
     const err = args[0] as Error | undefined
     banner(`error: ${err?.message ?? 'unknown'}`, 'red')
+    resolveDone()
   })
 
   banner(`✓ ready`, 'green')
@@ -94,6 +97,7 @@ export async function startTunnel(options: TunnelOptions): Promise<TunnelControl
   const stop = async () => {
     if (stopped) return
     stopped = true
+    if (signalHandler) process.off('SIGINT', signalHandler)
     tunnel.close()
     banner(`stopped — proxied ${requests} request${requests === 1 ? '' : 's'}`, 'cyan')
     resolveDone()
@@ -101,9 +105,10 @@ export async function startTunnel(options: TunnelOptions): Promise<TunnelControl
 
   // Hook Ctrl+C — but only if we're attached to a TTY (don't break tests)
   if (process.stdin.isTTY) {
-    process.on('SIGINT', () => {
+    signalHandler = () => {
       void stop()
-    })
+    }
+    process.on('SIGINT', signalHandler)
   }
 
   return {

--- a/packages/cli/tests/commands-misc.test.ts
+++ b/packages/cli/tests/commands-misc.test.ts
@@ -68,6 +68,7 @@ describe('registerInitCommand — interactive not cancelled', () => {
       tools: [] as never[],
       memory: 'none' as const,
       packageManager: 'pnpm' as const,
+      force: false,
     }
 
     const printNextStepsMock = vi.fn()

--- a/packages/cli/tests/commands.test.ts
+++ b/packages/cli/tests/commands.test.ts
@@ -181,7 +181,10 @@ describe('registerRagCommand', () => {
     registerRagCommand(program)
 
     // loadConfig returns nothing useful
-    vi.doMock('../src/config', () => ({ loadConfig: vi.fn().mockResolvedValue({}) }))
+    vi.doMock('../src/config', () => ({
+      loadConfig: vi.fn().mockResolvedValue({}),
+      redactConfig: (value: unknown) => value,
+    }))
 
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit') })

--- a/packages/cli/tests/components-fetch.test.ts
+++ b/packages/cli/tests/components-fetch.test.ts
@@ -83,6 +83,11 @@ describe('resolveAuthHeader', () => {
     })
     expect(resolveAuthHeader('https://acme.internal/ak', config, {})).toEqual({})
     expect(resolveAuthHeader('https://registry.agentskit.io', config, { ACME_TOKEN: 'sek' })).toEqual({})
+    expect(resolveAuthHeader('https://acme.internal/ak-evasion', config, { ACME_TOKEN: 'sek' })).toEqual({})
+    expect(resolveAuthHeader('https://acme.internal.evil/ak', config, { ACME_TOKEN: 'sek' })).toEqual({})
+    expect(resolveAuthHeader('https://acme.internal/ak/r/chat', config, { ACME_TOKEN: 'sek' })).toEqual({
+      authorization: 'Bearer sek',
+    })
   })
 })
 

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -113,4 +113,10 @@ describe('loadConfig', () => {
       nested: { token: '[REDACTED]' },
     })
   })
+
+  it('redacts secret values in environment maps without hiding the variable name', () => {
+    expect(redactConfig({ mcp: { servers: { local: { env: { OPENAI_API_KEY: 'secret' } } } } })).toEqual({
+      mcp: { servers: { local: { env: { OPENAI_API_KEY: '[REDACTED]' } } } },
+    })
+  })
 })

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { loadConfig } from '../src/config'
+import { loadConfig, redactConfig } from '../src/config'
 import { writeFile, mkdtemp, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -61,11 +61,10 @@ describe('loadConfig', () => {
     expect(config!.defaults?.provider).toBe('openai')
   })
 
-  it('handles malformed JSON gracefully', async () => {
+  it('reports malformed JSON with its source path', async () => {
     await writeFile(join(dir, '.agentskit.config.json'), 'not json {{{')
 
-    const config = await loadConfig({ cwd: dir, home: null })
-    expect(config).toBeUndefined()
+    await expect(loadConfig({ cwd: dir, home: null })).rejects.toThrow(/Failed to load JSON config/)
   })
 
   it('loads full config with all fields', async () => {
@@ -106,5 +105,12 @@ describe('loadConfig', () => {
 
     const config = await loadConfig({ cwd: dir, home: null })
     expect(config).toBeUndefined()
+  })
+
+  it('redacts secret-shaped fields for display', () => {
+    expect(redactConfig({ defaults: { apiKey: 'secret', apiKeyEnv: 'OPENAI_API_KEY' }, nested: { token: 'x' } })).toEqual({
+      defaults: { apiKey: '[REDACTED]', apiKeyEnv: 'OPENAI_API_KEY' },
+      nested: { token: '[REDACTED]' },
+    })
   })
 })

--- a/packages/cli/tests/dev.test.ts
+++ b/packages/cli/tests/dev.test.ts
@@ -68,7 +68,7 @@ describe('startDev', () => {
     })
 
     expect(spawnSpy).toHaveBeenCalledTimes(1)
-    expect(spawnSpy).toHaveBeenCalledWith('tsx', [entry])
+    expect(spawnSpy).toHaveBeenCalledWith(process.execPath, [expect.stringContaining('tsx'), entry])
     expect(controller.restarts()).toBe(1)
     void controller.stop()
   })
@@ -139,7 +139,10 @@ describe('startDev', () => {
       stderr: { write: () => true } as NodeJS.WritableStream,
     })
 
-    expect(spawnSpy).toHaveBeenCalledWith('tsx', [entry, '--task', 'hello world'])
+    expect(spawnSpy).toHaveBeenCalledWith(
+      process.execPath,
+      [expect.stringContaining('tsx'), entry, '--task', 'hello world'],
+    )
     void controller.stop()
   })
 

--- a/packages/cli/tests/hooks.test.ts
+++ b/packages/cli/tests/hooks.test.ts
@@ -110,6 +110,6 @@ describe('HookDispatcher', () => {
     )
     const result = await dispatcher.dispatch('SessionStart', { event: 'SessionStart' })
     expect(errors).toHaveLength(1)
-    expect(result.blocked).toBe(false)
+    expect(result.blocked).toBe(true)
   })
 })

--- a/packages/cli/tests/hooks.test.ts
+++ b/packages/cli/tests/hooks.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { HookDispatcher } from '../src/extensibility/hooks'
+import { configHooksToHandlers } from '../src/extensibility/hooks'
 import type { HookHandler } from '../src/extensibility/plugins'
 
 describe('HookDispatcher', () => {
@@ -112,4 +113,15 @@ describe('HookDispatcher', () => {
     expect(errors).toHaveLength(1)
     expect(result.blocked).toBe(true)
   })
+})
+
+describe('shell hooks', () => {
+  it('blocks unbounded stdout instead of retaining it', async () => {
+    const [handler] = configHooksToHandlers({
+      SessionStart: [{ run: `node -e "process.stdout.write('x'.repeat(100000))"` }],
+    })
+    const result = await handler!.run({ event: 'SessionStart' })
+    expect(result).toMatchObject({ decision: 'block' })
+    expect((result as { reason?: string }).reason).toContain('output exceeded')
+  }, 10_000)
 })

--- a/packages/cli/tests/init-writer.test.ts
+++ b/packages/cli/tests/init-writer.test.ts
@@ -1,0 +1,16 @@
+import { mkdtemp, readFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { writeStarterProject } from '../src/init-writer'
+import type { StarterKind } from '../src/init'
+
+describe('init writer', () => {
+  it('aligns generated package versions before writing', async () => {
+    const targetDir = await mkdtemp(path.join(os.tmpdir(), 'agentskit-init-writer-'))
+    const render = () => ({ 'package.json': JSON.stringify({ dependencies: { '@agentskit/react': '0.0.0' } }) })
+    const renderers = Object.fromEntries((['react', 'nextjs', 'ink', 'runtime', 'multi-agent', 'sveltekit', 'nuxt', 'vite-ink', 'cloudflare-workers', 'bun', 'expo', 'deno-deploy', 'angular'] as StarterKind[]).map(kind => [kind, render])) as Record<StarterKind, typeof render>
+    await writeStarterProject({ targetDir, template: 'react' }, renderers)
+    expect(await readFile(path.join(targetDir, 'package.json'), 'utf8')).toContain('^0.8.3')
+  })
+})

--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -285,6 +285,7 @@ describe('@agentskit/cli', () => {
 
     const denoConfig = JSON.parse(await readFile(path.join(tempDir, 'deno.json'), 'utf8'))
     expect(denoConfig.tasks.deploy).toContain('deployctl')
+    expect(denoConfig.imports['@agentskit/adapters']).toBe('npm:@agentskit/adapters@^0.15.2')
 
     const main = await readFile(path.join(tempDir, 'main.ts'), 'utf8')
     expect(main).toContain('Deno.serve')

--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile } from 'node:fs/promises'
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -28,6 +28,21 @@ describe('@agentskit/cli', () => {
     expect(packageJson).toContain('@agentskit/react')
     expect(appFile).toContain('useChat')
     expect(mainFile).toContain('createRoot')
+  })
+
+  it('refuses non-empty targets by default and atomically replaces generated files with force', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'agentskit-cli-'))
+    await writeFile(path.join(tempDir, 'keep.txt'), 'keep me', 'utf8')
+
+    await expect(writeStarterProject({ targetDir: tempDir, template: 'react' })).rejects.toThrow(
+      /not empty/,
+    )
+
+    await writeStarterProject({ targetDir: tempDir, template: 'react', force: true })
+    expect(await readFile(path.join(tempDir, 'keep.txt'), 'utf8')).toBe('keep me')
+    expect(await readFile(path.join(tempDir, 'package.json'), 'utf8')).toContain(
+      '"@agentskit/react": "^0.8.3"',
+    )
   })
 
   it('uses environment variables for openai', () => {

--- a/packages/cli/tests/mcp-extended.test.ts
+++ b/packages/cli/tests/mcp-extended.test.ts
@@ -51,6 +51,16 @@ rl.on('line', (line) => {
 })
 `
 
+const OVERSIZED_SERVER_SRC = `
+const rl = require('readline').createInterface({ input: process.stdin })
+function send(obj) { process.stdout.write(JSON.stringify(obj) + '\\n') }
+rl.on('line', (line) => {
+  const msg = JSON.parse(line)
+  if (msg.method === 'initialize') send({ jsonrpc: '2.0', id: msg.id, result: {} })
+  if (msg.method === 'tools/list') send({ jsonrpc: '2.0', id: msg.id, result: { tools: [{ name: 'x'.repeat(1024 * 1024) }] } })
+})
+`
+
 describe('McpClient — request on non-started client', () => {
   it('rejects immediately when client not started', async () => {
     const client = new McpClient({
@@ -126,6 +136,24 @@ describe('McpClient — onStdout parse error', () => {
       await client.start()
       // The malformed line should have triggered onError
       expect(errors.length).toBeGreaterThanOrEqual(1)
+    } finally {
+      client.dispose()
+    }
+  }, 10_000)
+})
+
+describe('McpClient — frame limits', () => {
+  it('rejects an oversized response and disposes the server', async () => {
+    const errors: unknown[] = []
+    const client = new McpClient(
+      { name: 'oversized-srv', command: process.execPath, args: ['-e', OVERSIZED_SERVER_SRC], timeout: 5000 },
+      err => errors.push(err),
+    )
+    try {
+      await client.start()
+      await expect(client.listTools()).rejects.toThrow(/client disposed/)
+      expect(errors).toHaveLength(1)
+      expect(String(errors[0])).toContain('frame exceeded')
     } finally {
       client.dispose()
     }

--- a/packages/cli/tests/registry.test.ts
+++ b/packages/cli/tests/registry.test.ts
@@ -23,6 +23,11 @@ const META = {
 }
 
 describe('fetchAgent', () => {
+  it('rejects traversal-shaped agent ids before making a request', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch
+    await expect(fetchAgent('../secrets', { fetchImpl })).rejects.toThrow(/Invalid registry agent id/)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
   it('uses the hosted index when it has inlined sources', async () => {
     const hosted = { ...META, sources: [{ path: 'agent.ts', content: 'export const x = 1' }] }
     const fetchImpl = vi.fn(async (url: string) => {
@@ -116,6 +121,21 @@ describe('addAgent', () => {
       },
     })
     expect(writes).toEqual(['agents/research/agent.ts'])
+  })
+
+  it('checks all conflicts before writing any source', async () => {
+    const hosted = { ...META, sources: [
+      { path: 'agent.ts', content: 'CODE' },
+      { path: 'README.md', content: 'README' },
+    ] }
+    const fetchImpl = vi.fn(async () => jsonResponse(hosted)) as unknown as typeof fetch
+    const writes: string[] = []
+    await expect(addAgent('research', {
+      fetchImpl,
+      existsImpl: async path => path.endsWith('README.md'),
+      writeFileImpl: async path => { writes.push(path) },
+    })).rejects.toThrow(/already exists/)
+    expect(writes).toEqual([])
   })
 })
 

--- a/packages/cli/tests/registry.test.ts
+++ b/packages/cli/tests/registry.test.ts
@@ -137,6 +137,27 @@ describe('addAgent', () => {
     })).rejects.toThrow(/already exists/)
     expect(writes).toEqual([])
   })
+
+  it('rejects a symlinked destination ancestor before writing', async () => {
+    const { mkdtemp, symlink, rm } = await import('node:fs/promises')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+    const root = await mkdtemp(join(tmpdir(), 'agentskit-registry-link-'))
+    const outside = await mkdtemp(join(tmpdir(), 'agentskit-registry-outside-'))
+    try {
+      await symlink(outside, join(root, 'agents'), 'dir')
+      const hosted = { ...META, sources: [{ path: 'agent.ts', content: 'CODE' }] }
+      const fetchImpl = vi.fn(async () => jsonResponse(hosted)) as unknown as typeof fetch
+      await expect(addAgent('research', {
+        fetchImpl,
+        outDir: join(root, 'agents'),
+        writeFileImpl: async () => {},
+      })).rejects.toThrow(/symlink ancestor/)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+      await rm(outside, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('lineDiff', () => {

--- a/packages/cli/tests/run-agent.test.ts
+++ b/packages/cli/tests/run-agent.test.ts
@@ -48,10 +48,10 @@ describe('runAgent', () => {
 
     await expect(
       runAgent('task', { provider: 'demo', skill: 'researcher', skills: 'coder,planner' }),
-    ).rejects.toThrow('exit')
+    ).rejects.toThrow('mutually exclusive')
 
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('mutually exclusive'))
-    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(stderrSpy).not.toHaveBeenCalled()
+    expect(exitSpy).not.toHaveBeenCalled()
   })
 
   it('uses skills flag when provided', async () => {

--- a/packages/cli/tests/shell-hooks.test.ts
+++ b/packages/cli/tests/shell-hooks.test.ts
@@ -98,12 +98,12 @@ describe('shell hook execution (runShellHook via handler)', () => {
     }
   })
 
-  it('treats non-JSON stdout as continue', async () => {
+  it('blocks on non-JSON stdout', async () => {
     const [handler] = configHooksToHandlers({
       SessionStart: [{ run: 'printf "not json at all"', timeout: 3000 }],
     })!
     const result = await handler!.run(PAYLOAD)
-    expect(result.decision).toBe('continue')
+    expect(result.decision).toBe('block')
   })
 
   it('blocks when timeout exceeded', async () => {

--- a/packages/templates/src/blueprints/adapter.ts
+++ b/packages/templates/src/blueprints/adapter.ts
@@ -29,7 +29,8 @@ export function ${camelCase(name)}(config: ${pascalCase(name)}Config): AdapterFa
             yield { type: 'done' }
           } catch (err) {
             if (err instanceof DOMException && err.name === 'AbortError') return
-            yield { type: 'error', content: err instanceof Error ? err.message : String(err) }
+            const error = err instanceof Error ? err : new Error(String(err))
+            yield { type: 'error', content: error.message, metadata: { error } }
           }
         },
         abort: () => {

--- a/packages/templates/src/blueprints/embedder.ts
+++ b/packages/templates/src/blueprints/embedder.ts
@@ -12,29 +12,46 @@ export interface ${pascalCase(name)}EmbedderConfig {
   apiKey: string
   model?: string
   baseUrl?: string
+  timeoutMs?: number
+  maxResponseBytes?: number
 }
 
 export function ${camelCase(name)}Embedder(config: ${pascalCase(name)}EmbedderConfig): EmbedFn {
   const model = config.model ?? 'text-embedding-3-small'
   const baseUrl = (config.baseUrl ?? 'https://api.example.com').replace(/\\/$/, '')
+  const timeoutMs = config.timeoutMs ?? 15_000
+  const maxResponseBytes = config.maxResponseBytes ?? 1_048_576
 
   return async (text: string): Promise<number[]> => {
     const url = \`\${baseUrl}/v1/embeddings\`
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        authorization: \`Bearer \${config.apiKey}\`,
-      },
-      body: JSON.stringify({ model, input: text }),
-    })
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    let response: Response
+    let body: ArrayBuffer
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        signal: controller.signal,
+        headers: {
+          'content-type': 'application/json',
+          authorization: \`Bearer \${config.apiKey}\`,
+        },
+        body: JSON.stringify({ model, input: text }),
+      })
+      body = await response.arrayBuffer()
+    } finally {
+      clearTimeout(timer)
+    }
     if (!response.ok) {
       const body = await response.text().catch(() => '')
       throw new Error(\`embedder \${model} HTTP \${response.status}: \${body.slice(0, 200)}\`)
     }
-    const json = (await response.json()) as { data?: Array<{ embedding: number[] }> }
+    if (body!.byteLength > maxResponseBytes) throw new Error(\`embedder \${model}: response too large\`)
+    const json = JSON.parse(new TextDecoder().decode(body!)) as { data?: Array<{ embedding: unknown }> }
     const first = json.data?.[0]?.embedding
-    if (!first) throw new Error(\`embedder \${model}: response missing data[0].embedding\`)
+    if (!Array.isArray(first) || first.length === 0 || first.some(value => typeof value !== 'number' || !Number.isFinite(value))) {
+      throw new Error(\`embedder \${model}: response has an invalid embedding vector\`)
+    }
     return first
   }
 }
@@ -96,34 +113,38 @@ export interface ${pascalCase(name)}Config {
   onProgress?: (info: { progress: number; text: string }) => void
 }
 
-let cached: Promise<${pascalCase(name)}EngineLike> | null = null
-
 async function loadEngine(config: ${pascalCase(name)}Config): Promise<${pascalCase(name)}EngineLike> {
   if (config.engine) return config.engine
-  if (cached) return cached
-  cached = (async () => {
+  return (async () => {
     // TODO: replace this dynamic import with the real engine loader,
     // e.g. \`await import('@mlc-ai/web-llm')\` for MLC.
     throw new Error('${name} engine loader not implemented')
   })()
-  return cached
 }
 
 export function ${camelCase(name)}(config: ${pascalCase(name)}Config): AdapterFactory {
+  let cached: Promise<${pascalCase(name)}EngineLike> | null = null
   return {
     capabilities: { tools: false },
     createSource: (request) => {
       let aborted = false
+      let active: AsyncIterator<unknown> | undefined
       return {
         stream: async function* (): AsyncIterableIterator<StreamChunk> {
           try {
-            const engine = await loadEngine(config)
+            if (!cached) cached = loadEngine(config).catch(err => { cached = null; throw err })
+            const engine = await cached
+            await engine.reload(config.model)
             const messages = request.messages.map(m => ({
               role: String(m.role),
               content: typeof m.content === 'string' ? m.content : '',
             }))
-            const iter = engine.chat.completions.create({ messages, stream: true })
-            for await (const chunk of iter) {
+            const iterator = engine.chat.completions.create({ messages, stream: true })[Symbol.asyncIterator]()
+            active = iterator
+            while (true) {
+              const next = await iterator.next()
+              if (next.done) break
+              const chunk = next.value as { choices?: Array<{ delta?: { content?: string } }> }
               if (aborted) return
               const delta = chunk.choices?.[0]?.delta?.content
               if (delta) yield { type: 'text', content: delta }
@@ -135,6 +156,7 @@ export function ${camelCase(name)}(config: ${pascalCase(name)}Config): AdapterFa
         },
         abort: () => {
           aborted = true
+          void active?.return?.()
         },
       }
     },

--- a/packages/templates/src/blueprints/embedder.ts
+++ b/packages/templates/src/blueprints/embedder.ts
@@ -42,11 +42,11 @@ export function ${camelCase(name)}Embedder(config: ${pascalCase(name)}EmbedderCo
     } finally {
       clearTimeout(timer)
     }
-    if (!response.ok) {
-      const body = await response.text().catch(() => '')
-      throw new Error(\`embedder \${model} HTTP \${response.status}: \${body.slice(0, 200)}\`)
-    }
     if (body!.byteLength > maxResponseBytes) throw new Error(\`embedder \${model}: response too large\`)
+    if (!response.ok) {
+      const text = new TextDecoder().decode(body!)
+      throw new Error(\`embedder \${model} HTTP \${response.status}: \${text.slice(0, 200)}\`)
+    }
     const json = JSON.parse(new TextDecoder().decode(body!)) as { data?: Array<{ embedding: unknown }> }
     const first = json.data?.[0]?.embedding
     if (!Array.isArray(first) || first.length === 0 || first.some(value => typeof value !== 'number' || !Number.isFinite(value))) {
@@ -151,7 +151,8 @@ export function ${camelCase(name)}(config: ${pascalCase(name)}Config): AdapterFa
             }
             yield { type: 'done' }
           } catch (err) {
-            yield { type: 'error', content: err instanceof Error ? err.message : String(err) }
+            const error = err instanceof Error ? err : new Error(String(err))
+            yield { type: 'error', content: error.message, metadata: { error } }
           }
         },
         abort: () => {

--- a/packages/templates/src/blueprints/flow.ts
+++ b/packages/templates/src/blueprints/flow.ts
@@ -88,6 +88,12 @@ A visual flow + handler registry for AgentsKit.
 
 ## Run
 
+Install the CLI once in this package before running the commands below:
+
+\`\`\`bash
+npm install --save-dev @agentskit/cli
+\`\`\`
+
 \`\`\`bash
 agentskit flow validate flow.yaml --registry ./dist/index.js
 agentskit flow render   flow.yaml > flow.mmd

--- a/packages/templates/src/blueprints/flow.ts
+++ b/packages/templates/src/blueprints/flow.ts
@@ -11,6 +11,27 @@ import { camelCase, pascalCase } from './utils'
 export function generateFlowSource(name: string): string {
   return `import type { FlowRegistry } from '@agentskit/runtime'
 
+const ALLOWED_ORIGINS = new Set(['https://example.com'])
+const MAX_RESPONSE_BYTES = 1_048_576
+
+async function safeFetchText(rawUrl: string): Promise<string> {
+  const url = new URL(rawUrl)
+  if (url.protocol !== 'https:' || !ALLOWED_ORIGINS.has(url.origin)) {
+    throw new Error(\`http.get blocked URL origin: \${url.origin}\`)
+  }
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 15_000)
+  try {
+    const response = await fetch(url, { signal: controller.signal })
+    if (!response.ok) throw new Error(\`http.get \${response.status}: \${url}\`)
+    const body = await response.arrayBuffer()
+    if (body.byteLength > MAX_RESPONSE_BYTES) throw new Error('http.get response too large')
+    return new TextDecoder().decode(body)
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 /**
  * Handler registry for the \`${name}\` flow. Each key matches the
  * \`run:\` field on a node in the flow's YAML / object definition.
@@ -24,10 +45,7 @@ export function generateFlowSource(name: string): string {
 export const ${camelCase(name)}Registry: FlowRegistry = {
   // TODO: replace these stubs with real handlers.
   'http.get': async ({ with: w }) => {
-    const url = String(w.url ?? '')
-    const response = await fetch(url)
-    if (!response.ok) throw new Error(\`http.get \${response.status}: \${url}\`)
-    return await response.text()
+    return safeFetchText(String(w.url ?? ''))
   },
 
   'json.parse': ({ deps }) => {

--- a/packages/templates/src/blueprints/memory.ts
+++ b/packages/templates/src/blueprints/memory.ts
@@ -134,7 +134,7 @@ export function generateChatMemorySource(name: string): string {
 import type { ChatMemory, Message, MemoryRecord } from '@agentskit/core'
 
 export interface ${pascalCase(name)}Config {
-  /** Connection URL or driver-specific config. */
+  /** Connection URL or driver-specific config; persistence must be wired below. */
   url: string
   /** Logical conversation id. Defaults to 'default'. */
   conversationId?: string
@@ -145,8 +145,8 @@ const EMPTY_RECORD: MemoryRecord = { version: 1, messages: [] }
 export function ${camelCase(name)}(config: ${pascalCase(name)}Config): ChatMemory {
   const conversationId = config.conversationId ?? 'default'
 
-  // TODO: wire your backend client here (open connection, prepare statements, etc.)
-  // In-memory stand-in so the skeleton typechecks and the contract test can run.
+  // This generated implementation is an in-memory stand-in until the backend
+  // client is wired below; it is not persistent across process restarts.
   let store: MemoryRecord = EMPTY_RECORD
 
   return {

--- a/packages/templates/src/blueprints/memory.ts
+++ b/packages/templates/src/blueprints/memory.ts
@@ -19,19 +19,34 @@ export interface ${pascalCase(name)}Config {
   topK?: number
   /** Override fetch (mainly for tests). */
   fetch?: typeof globalThis.fetch
+  timeoutMs?: number
+  maxResponseBytes?: number
 }
 
 async function call<T>(config: ${pascalCase(name)}Config, path: string, body: unknown): Promise<T> {
   const fetchImpl = config.fetch ?? globalThis.fetch
-  const response = await fetchImpl(\`\${config.url}\${path}\`, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      ...(config.apiKey ? { authorization: \`Bearer \${config.apiKey}\` } : {}),
-    },
-    body: JSON.stringify(body),
-  })
-  const text = await response.text()
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), config.timeoutMs ?? 15_000)
+  let response: Response
+  let responseBody: ArrayBuffer
+  try {
+    response = await fetchImpl(\`\${config.url}\${path}\`, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        'content-type': 'application/json',
+        ...(config.apiKey ? { authorization: \`Bearer \${config.apiKey}\` } : {}),
+      },
+      body: JSON.stringify(body),
+    })
+    responseBody = await response.arrayBuffer()
+  } finally {
+    clearTimeout(timer)
+  }
+  if (responseBody!.byteLength > (config.maxResponseBytes ?? 1_048_576)) {
+    throw new MemoryError({ code: ErrorCodes.AK_MEMORY_REMOTE_HTTP, message: \`${name}: response too large\` })
+  }
+  const text = new TextDecoder().decode(responseBody!)
   if (!response.ok) {
     throw new MemoryError({
       code: ErrorCodes.AK_MEMORY_REMOTE_HTTP,

--- a/packages/templates/src/blueprints/package-json.ts
+++ b/packages/templates/src/blueprints/package-json.ts
@@ -7,10 +7,10 @@ import { packageName } from './utils'
  * Only packages actually imported by the generated source are listed.
  * Versions are pinned with caret ranges — never wildcards.
  * - Everyone depends on `@agentskit/core` ^1.0.0
- * - `flow` also depends on `@agentskit/runtime` ^0.10.0
+ * - `flow` also depends on `@agentskit/runtime` ^0.10.15
  */
 const EXTRA_DEPS: Partial<Record<ScaffoldType, Record<string, string>>> = {
-  flow: { '@agentskit/runtime': '^0.10.0' },
+  flow: { '@agentskit/runtime': '^0.10.15' },
 }
 
 export function generatePackageJson(config: ScaffoldConfig): string {

--- a/packages/templates/src/blueprints/readme.ts
+++ b/packages/templates/src/blueprints/readme.ts
@@ -2,6 +2,7 @@ import type { ScaffoldConfig } from '../scaffold'
 import { camelCase, packageName } from './utils'
 
 export function generateReadme(config: ScaffoldConfig): string {
+  const symbol = config.type === 'embedder' ? `${camelCase(config.name)}Embedder` : camelCase(config.name)
   return `# ${packageName(config.name)}
 
 ${config.description ?? `AgentsKit ${config.type}: ${config.name}`}
@@ -15,7 +16,7 @@ npm install ${packageName(config.name)}
 ## Usage
 
 \`\`\`ts
-import { ${camelCase(config.name)} } from '${packageName(config.name)}'
+import { ${symbol} } from '${packageName(config.name)}'
 
 // TODO: add usage example
 \`\`\`

--- a/packages/templates/src/scaffold-config.ts
+++ b/packages/templates/src/scaffold-config.ts
@@ -36,6 +36,15 @@ export interface ScaffoldConfig {
 export const SAFE_PACKAGE_NAME =
   /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/
 
+const RESERVED_IDENTIFIERS = new Set([
+  'await', 'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger',
+  'default', 'delete', 'do', 'else', 'enum', 'export', 'extends', 'false',
+  'finally', 'for', 'function', 'if', 'implements', 'import', 'in', 'instanceof',
+  'interface', 'let', 'new', 'null', 'package', 'private', 'protected', 'public',
+  'return', 'static', 'super', 'switch', 'this', 'throw', 'true', 'try', 'typeof',
+  'var', 'void', 'while', 'with', 'yield',
+])
+
 const MAX_DESCRIPTION_LENGTH = 1000
 
 export function invalidConfig(
@@ -84,6 +93,12 @@ export function validateScaffoldConfig(config: ScaffoldConfig): void {
     throw invalidConfig(
       `Scaffold name "${config.name}" is not a safe unscoped npm package id`,
       'Must start with a lowercase letter; only lowercase alphanumerics and single hyphens between segments. No scopes (@), slashes, dots, spaces, or uppercase.',
+    )
+  }
+  if (RESERVED_IDENTIFIERS.has(config.name)) {
+    throw invalidConfig(
+      `Scaffold name "${config.name}" is a reserved TypeScript identifier`,
+      'Choose a name such as "my-tool" that is valid in both npm and TypeScript.',
     )
   }
 

--- a/packages/templates/tests/scaffold-security.test.ts
+++ b/packages/templates/tests/scaffold-security.test.ts
@@ -67,6 +67,11 @@ describe('validateScaffoldConfig edge cases', () => {
       }),
     ).not.toThrow()
   })
+
+  it('rejects names that become reserved TypeScript identifiers', () => {
+    expect(() => validateScaffoldConfig({ type: 'tool', name: 'class', dir: '/tmp/out' })).toThrow(/reserved TypeScript/)
+    expect(() => validateScaffoldConfig({ type: 'tool', name: 'return', dir: '/tmp/out' })).toThrow(/reserved TypeScript/)
+  })
 })
 
 describe('scaffold-fs helpers', () => {
@@ -143,6 +148,7 @@ describe('scaffold-fs helpers', () => {
       }),
     ).rejects.toThrow(/escapes parent/)
   })
+
 
   it('writePackageAtomically overwrites with backup and leaves no staging', async () => {
     const finalRoot = join(dir, 'ow')

--- a/packages/templates/tests/scaffold.test.ts
+++ b/packages/templates/tests/scaffold.test.ts
@@ -179,6 +179,7 @@ describe('scaffold', () => {
     const readme = await readFile(join(dir, 'nightly-refresh', 'README.md'), 'utf8')
     expect(readme).toContain('nightlyRefreshRegistry')
     expect(readme).toContain('compileFlow')
+    expect(readme).toContain('npm install --save-dev @agentskit/cli')
 
     const test = await readFile(join(dir, 'nightly-refresh', 'tests', 'index.test.ts'), 'utf8')
     expect(test).toContain('compileFlow')
@@ -188,7 +189,7 @@ describe('scaffold', () => {
     const pkg = JSON.parse(
       await readFile(join(dir, 'nightly-refresh', 'package.json'), 'utf8'),
     ) as { dependencies: Record<string, string> }
-    expect(pkg.dependencies['@agentskit/runtime']).toBe('^0.10.0')
+    expect(pkg.dependencies['@agentskit/runtime']).toBe('^0.10.15')
     expect(pkg.dependencies['@agentskit/core']).toBe('^1.0.0')
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -899,6 +899,9 @@ importers:
       react:
         specifier: ^19.2.8
         version: 19.2.8
+      tsx:
+        specifier: ^4.23.5
+        version: 4.23.5
       yaml:
         specifier: ^2.9.0
         version: 2.9.0

--- a/readme-standard-v1.json
+++ b/readme-standard-v1.json
@@ -287,7 +287,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:3cb2f0ce68a2b1c6b56a9d5c4a93f6dc2d7d52cc0d240bf9d95434320ccfdea6"
+        "sourceHash": "sha256:5405c5141ffc68230b3659ceb1372fabde7af94809fb36a86de04e4403695729"
       },
       "exceptions": []
     },
@@ -445,7 +445,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:245898b8cb741aaa920b63441b48e8a4edc511b8c0899481bffa1007c385bdb5"
+        "sourceHash": "sha256:01e999d26cf4990d6bcc4007f75521203ea6e77bd23949e199dcbf461d40421e"
       },
       "exceptions": []
     },


### PR DESCRIPTION
## Summary

This stacked PR isolates the `@agentskit/adapters` remediation batch. It is based on the core, tools/MCP, and runtime/statechart PRs.

## Changes

- Hardened CLI provider manifests, process boundaries, deadlines, cancellation, and output handling.
- Preserved shell-free, provider-neutral, configurable adapter composition.
- Added regression coverage for CLI transport and retry boundaries.
- Updated adapter documentation and added a release changeset.

## Verification

- Adapter tests and TypeScript checks passed in the source branch.
- Packed-consumer checks covered the adapter public exports in the source branch.

## Scope

- No external issues were created, edited, or closed.
- No publication or deployment was performed.
- `ak-verify` remains unavailable; formal finding resolution is not claimed.
