### PR TITLE
fix(release): authenticate npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           node-version: 22
           package-manager-cache: false
+          registry-url: https://registry.npmjs.org
       - name: Pin npm release client
         env:
           NPM_TARBALL_URL: https://registry.npmjs.org/npm/-/npm-11.18.0.tgz
@@ -116,6 +117,7 @@ jobs:
           github-token: ${{ steps.release_app_token.outputs.token }}
         env:
           GITHUB_TOKEN: ${{ steps.release_app_token.outputs.token }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Recover committed unpublished versions
@@ -125,6 +127,7 @@ jobs:
           pnpm changeset publish
           echo "published=true" >> "$GITHUB_OUTPUT"
         env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Generate SBOM (CycloneDX)

--- a/scripts/release-workflow-auth.test.mjs
+++ b/scripts/release-workflow-auth.test.mjs
@@ -30,12 +30,10 @@ describe('release workflow authentication', () => {
     assert.match(workflow, /persist-credentials: false/)
   })
 
-  test('keeps npm trusted publishing free of token-auth config', () => {
-    // setup-node writes a token placeholder to .npmrc when registry-url is set.
-    // That placeholder prevents npm trusted publishing from using OIDC when no
-    // NODE_AUTH_TOKEN is configured.
-    assert.doesNotMatch(workflow, /registry-url:/)
-    assert.doesNotMatch(workflow, /NPM_TOKEN|NODE_AUTH_TOKEN/)
+  test('passes the repository npm token only to publish commands', () => {
+    assert.match(workflow, /registry-url: https:\/\/registry\.npmjs\.org/)
+    assert.match(workflow, /NODE_AUTH_TOKEN: \$\{\{ secrets\.NPM_TOKEN \}\}/g)
+    assert.doesNotMatch(workflow, /NPM_TOKEN: /)
   })
 
   test('verifies the npm release client tarball before activating it', () => {


### PR DESCRIPTION
## Summary
- restore explicit npm registry configuration for the release runner
- pass the existing repository NPM_TOKEN only to Changesets publish paths
- keep npm provenance enabled and update the auth regression test

## Validation
- `node --test scripts/release-workflow-auth.test.mjs`
- `pnpm check:quality-gates` (40/40)

This unblocks the already-merged version train; after merge, dispatch Release with `recover_unpublished=true`.