### PR TITLE
fix(release): restore npm OIDC registry configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           node-version: 22
           package-manager-cache: false
+          registry-url: https://registry.npmjs.org
       - name: Pin npm release client
         env:
           NPM_TARBALL_URL: https://registry.npmjs.org/npm/-/npm-11.18.0.tgz

--- a/scripts/release-workflow-auth.test.mjs
+++ b/scripts/release-workflow-auth.test.mjs
@@ -30,11 +30,8 @@ describe('release workflow authentication', () => {
     assert.match(workflow, /persist-credentials: false/)
   })
 
-  test('keeps npm trusted publishing free of token-auth config', () => {
-    // setup-node writes a token placeholder to .npmrc when registry-url is set.
-    // That placeholder prevents npm trusted publishing from using OIDC when no
-    // NODE_AUTH_TOKEN is configured.
-    assert.doesNotMatch(workflow, /registry-url:/)
+  test('configures npm trusted publishing without token-auth config', () => {
+    assert.match(workflow, /registry-url: https:\/\/registry\.npmjs\.org/)
     assert.doesNotMatch(workflow, /NPM_TOKEN|NODE_AUTH_TOKEN/)
   })
 


### PR DESCRIPTION
## Summary
- restore the npm registry URL required by the trusted-publishing runner
- keep the release workflow OIDC-only with no saved npm token
- update the authentication regression test

## Validation
- `node --test scripts/release-workflow-auth.test.mjs` (5/5)
- `pnpm check:publication-surface` (22 public, 3 private)

The existing npm Trusted Publisher for `@agentskit/mcp` matches `AgentsKit-io/agentskit`, `release.yml`, and environment `npm`.