### PR TITLE
fix(release): publish Changesets through npm OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,12 @@ jobs:
 
       - name: Check for changeset
         run: |
-          # Skip if PR only touches docs/examples (no package source changes)
+          # Skip if PR only touches docs/examples or package metadata.
           CHANGED=$(git diff --name-only origin/main...HEAD)
           echo "Changed files:"
           echo "$CHANGED"
 
-          NEEDS_CHANGESET=$(echo "$CHANGED" | grep -E '^packages/' | grep -vE '^packages/[^/]+/(tests?/|.*\.(test|spec)\.[^/]+$)' || true)
+          NEEDS_CHANGESET=$(echo "$CHANGED" | grep -E '^packages/' | grep -vE '^packages/[^/]+/(tests?/|.*\.(test|spec)\.[^/]+$|package\.json$)' || true)
 
           if [ -z "$NEEDS_CHANGESET" ]; then
             echo "No changes inside packages/ — changeset not required."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
         if: steps.release_intent.outputs.run == 'true' && inputs.recover_unpublished != true
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
-          publish: pnpm changeset publish
+          publish: node scripts/publish-with-npm.mjs
           version: pnpm release:version
           title: "chore: version packages"
           commit: "chore: version packages"
@@ -123,7 +123,7 @@ jobs:
         id: recovery_publish
         if: github.event_name == 'workflow_dispatch' && inputs.recover_unpublished
         run: |
-          pnpm changeset publish
+          node scripts/publish-with-npm.mjs
           echo "published=true" >> "$GITHUB_OUTPUT"
         env:
           NPM_CONFIG_PROVENANCE: true

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -97,7 +97,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/adapters",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/adapters"
   },
   "bugs": {

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -78,7 +78,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/angular",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/angular"
   },
   "bugs": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -91,7 +91,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/cli",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/cli"
   },
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -138,7 +138,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/core",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/core"
   },
   "bugs": {

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -130,7 +130,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/eval",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/eval"
   },
   "bugs": {

--- a/packages/ink/package.json
+++ b/packages/ink/package.json
@@ -73,7 +73,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/ink",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/ink"
   },
   "bugs": {

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -69,7 +69,7 @@
   "homepage": "https://www.agentskit.io/docs/for-agents/integrations",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/integrations"
   },
   "bugs": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -63,7 +63,7 @@
   "homepage": "https://www.agentskit.io/docs/agents/tools/mcp",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/mcp"
   },
   "author": "AgentsKit Contributors",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -87,7 +87,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/memory",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/memory"
   },
   "bugs": {

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -108,7 +108,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/observability",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/observability"
   },
   "bugs": {

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -87,7 +87,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/rag",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/rag"
   },
   "bugs": {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -76,7 +76,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/react-native",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/react-native"
   },
   "bugs": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -81,7 +81,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/react",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/react"
   },
   "bugs": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -70,7 +70,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/runtime",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/runtime"
   },
   "bugs": {

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -90,7 +90,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/sandbox",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/sandbox"
   },
   "bugs": {

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -68,7 +68,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/skills",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/skills"
   },
   "bugs": {

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -80,7 +80,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/solid",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/solid"
   },
   "bugs": {

--- a/packages/statechart/package.json
+++ b/packages/statechart/package.json
@@ -55,7 +55,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/statechart",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/statechart"
   },
   "bugs": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -73,7 +73,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/svelte",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/svelte"
   },
   "bugs": {

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -63,7 +63,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/templates",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/templates"
   },
   "bugs": {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -99,7 +99,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/tools",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/tools"
   },
   "bugs": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -72,7 +72,7 @@
   "homepage": "https://www.agentskit.io/docs/reference/packages/vue",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "url": "https://github.com/AgentsKit-io/agentskit",
     "directory": "packages/vue"
   },
   "bugs": {

--- a/readme-standard-v1.json
+++ b/readme-standard-v1.json
@@ -287,7 +287,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:b94399597ba759a91c6183ce3aa199f9bcb0307b7046488011ce6c62d17b5ac6"
+        "sourceHash": "sha256:707d6a2fa42c7c3bdb51811a98aefdec3eee79cb8b752e78dc40e3388672fe72"
       },
       "exceptions": []
     },
@@ -366,7 +366,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:0a3fcbadcf6c25acc73e050f420699f220379121644a786ae8f10e2f22a09937"
+        "sourceHash": "sha256:a27e91d06a386381aa5a69b2823ec7ad35ef108fa2cac28fc473ca618925f89e"
       },
       "exceptions": []
     },
@@ -445,7 +445,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:6d744a807be4681c98234198ce826da312f1c18e53a5cef37572b57541c74cff"
+        "sourceHash": "sha256:758d9e6ab07be349132672c15e2ccf7d0b1d2ef3be4be8af66f91cd4d851919b"
       },
       "exceptions": []
     },
@@ -524,7 +524,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:3ab04c71e149296f9156dcf9dc0b4e1b2ac7697c0ca3447f2d4d7c04f5da6664"
+        "sourceHash": "sha256:a921c5ab9fd7ffd691e4717b4a2a9ff18e5886d8df905117823d9e13cbc20cf7"
       },
       "exceptions": []
     },
@@ -603,7 +603,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:1b6cc15f359013519920fb8c131a0b681d01fc15f98d9eec3d85e0c225f1476d"
+        "sourceHash": "sha256:75dd1baeea78c96a26c888691b7c59bcb3cee8582d3be6b782a196187ccc85ce"
       },
       "exceptions": []
     },
@@ -761,7 +761,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:1f18431388574a8b46ea3a416d8ab3576e814df02002bd018e38397ff96b4633"
+        "sourceHash": "sha256:fe807aa5bba2210626363371e1a3a1b1bb362fb61136c855d4759dcb4b6abef0"
       },
       "exceptions": []
     },
@@ -840,7 +840,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:157dd3771e48bbb19e4f9872a73dda3f71d66bea520875b41ba86fbb4070b3d8"
+        "sourceHash": "sha256:5e154abbb7d1e2190bcf89946a101c86c174fcfb5f5efaa51c9db64764ba6b10"
       },
       "exceptions": []
     },
@@ -919,7 +919,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:4d99d88ec2b41b6bedabdd889afb55ac5344277a1a451395083dbf302cc1e5d4"
+        "sourceHash": "sha256:706d9d3cb244983165ed70cac1246377d69e3dab0d0c422ae64b5f0b7c2c2055"
       },
       "exceptions": []
     },
@@ -998,7 +998,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:327e5a352204adac0f8453f00631782766a7434d365164eec771118b1a405f8c"
+        "sourceHash": "sha256:3cd0c1066a814289a103cd8760a89ea4eb0d795467f09c76cb5ca39f8878c88d"
       },
       "exceptions": []
     },
@@ -1077,7 +1077,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:50f033727d8ab394b1cbcab9e00768b63f6be208745da02a81de01db8fa3c109"
+        "sourceHash": "sha256:7245467e3162fa33d298d1a463b0e2c4171fdf0081b7e124e5f362f8f631c1ab"
       },
       "exceptions": []
     },
@@ -1235,7 +1235,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:21af932f8e94b59faf0a1800617dc0d6c02759c5f004ecca7a5a4233567e602f"
+        "sourceHash": "sha256:f429ce04dba7613fc2a45247659387e3c8e9a4e697f68bb2b09eb7b449218f3b"
       },
       "exceptions": []
     },
@@ -1314,7 +1314,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:a6ca79dad45e1d89ad6ece7f1648bd182edc9b2ffbaee7724804dc2e9d42aea7"
+        "sourceHash": "sha256:734e8ddd5bbdfa0111515756226b13113d0c0c454de71aa14094344406575f02"
       },
       "exceptions": []
     },
@@ -1393,7 +1393,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:d4c037e1d81891a4e9a33e78b4b28979425da712a921119c9241b52b39f3c5f5"
+        "sourceHash": "sha256:f05ca4d2703bdd6abd28771afbaeb68a27201c6518ad581bd74770b6b0a27e2d"
       },
       "exceptions": []
     },
@@ -1472,7 +1472,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:16cedef516f597319783af1f17f4ba0e2901b865d74e54bc4355ccd84fc94bf6"
+        "sourceHash": "sha256:1ebdbf3b9b28e5497e59a25ff25c7ff82454c639d5215a1efa54032744ab5896"
       },
       "exceptions": []
     },
@@ -1551,7 +1551,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:ba421909f3688b2271973ce395af0c09f52a2ab82f278efcf26618659797b884"
+        "sourceHash": "sha256:30635d556c6326f8b7619be8f934ce45875191e1baafdb8505f126dd423d7920"
       },
       "exceptions": []
     },
@@ -1630,7 +1630,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:a968d9bcbb6d77a61a6a185a130ef2c6ba0f90c814178b9232c6c6f583cfc2bd"
+        "sourceHash": "sha256:6f054f01f3c1c632fe2ad98826d7027392c791189825480d8e72b5ff3e020a46"
       },
       "exceptions": []
     },
@@ -1709,7 +1709,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:52c8cc92ed4554d2b792f67cbe0e8cfd661c297ebdf2ddab0b1a177f3298d6f7"
+        "sourceHash": "sha256:1752e83c2cf60d9acac591416dc6de265f57042f949e6fdf86c56877d26641f4"
       },
       "exceptions": []
     },
@@ -1788,7 +1788,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:92d1e8ffeba5a51eb8b405b4a2e1c69f830c80aec18fd1bf67436763ca2fa3c1"
+        "sourceHash": "sha256:b38d4b138298d14531039020d5a451531a4009d11099afed4e6ca21cb0e47fac"
       },
       "exceptions": []
     },
@@ -1867,7 +1867,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:2ecba35f0d2c40aacc13dc25e3ada323d7ada165c9e661af390c9dbb263ad964"
+        "sourceHash": "sha256:c108dede2000e5e6d70a3b42940e5c89ad12899a2b532910c41e9790e4a8c84d"
       },
       "exceptions": []
     },
@@ -1946,7 +1946,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:2826ce0bb6f4f5879188540ab818682e853c9fb93bd3254d5601b788c1a64fef"
+        "sourceHash": "sha256:3cd803f18312dbe7a1df506cfb33c78f547d238514f2d02dad6fc6db427e8a3c"
       },
       "exceptions": []
     },
@@ -2025,7 +2025,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:a84489718b10000fe790d446875ceaa06335222d158c403132bbf1bb2d591382"
+        "sourceHash": "sha256:c2a6a79252f8e86ea9e90c8f1f2efeae9cecef02499bd37463670d2abb303560"
       },
       "exceptions": []
     },
@@ -2183,7 +2183,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:d7ee448cdbd18a16f4339e5ac064053a9b8f9aa9d16296dbd523cefed295d1e6"
+        "sourceHash": "sha256:14a29e9e818e8597580e75f152e0f6e289b7f080977f9f0bec6c5f2a455b1388"
       },
       "exceptions": []
     },

--- a/scripts/check-publication-surface.mjs
+++ b/scripts/check-publication-surface.mjs
@@ -2,6 +2,7 @@ import { readFile, readdir } from 'node:fs/promises'
 const packagesRoot = new URL('../packages/', import.meta.url)
 const releaseWorkflow = await readFile(new URL('../.github/workflows/release.yml', import.meta.url), 'utf8')
 const rootManifest = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
+const canonicalRepository = 'https://github.com/AgentsKit-io/agentskit'
 const manifests = []
 
 for (const directory of await readdir(packagesRoot)) {
@@ -35,6 +36,7 @@ for (const { directory, manifest } of manifests) {
     diagnostics.push(`${manifest.name}: private package cannot declare public access`)
   }
   if (!isPrivate) {
+    if (manifest.repository?.url !== canonicalRepository) diagnostics.push(`${manifest.name}: repository.url must exactly match ${canonicalRepository}`)
     if (manifest.publishConfig?.access !== 'public') diagnostics.push(`${manifest.name}: public package must declare publishConfig.access=public`)
     if (manifest.publishConfig?.provenance !== true) diagnostics.push(`${manifest.name}: public package must declare publishConfig.provenance=true`)
     const runtimeDependencies = {

--- a/scripts/publish-with-npm.mjs
+++ b/scripts/publish-with-npm.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import { readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)))
+const manifestPath = join(root, 'package.json')
+const lockPath = join(root, 'pnpm-lock.yaml')
+const lockBackupPath = `${lockPath}.npm-publish-backup-${process.pid}`
+const manifestSource = await readFile(manifestPath, 'utf8')
+const manifest = JSON.parse(manifestSource)
+
+delete manifest.packageManager
+await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+await rename(lockPath, lockBackupPath)
+
+try {
+  const result = spawnSync(
+    process.execPath,
+    [join(root, 'node_modules/@changesets/cli/bin.js'), 'publish', ...process.argv.slice(2)],
+    { cwd: root, env: process.env, stdio: 'inherit' },
+  )
+  if (result.error) throw result.error
+  process.exitCode = result.status ?? 1
+} finally {
+  await writeFile(manifestPath, manifestSource)
+  await rename(lockBackupPath, lockPath)
+}

--- a/scripts/release-workflow-auth.test.mjs
+++ b/scripts/release-workflow-auth.test.mjs
@@ -33,6 +33,7 @@ describe('release workflow authentication', () => {
   test('configures npm trusted publishing without token-auth config', () => {
     assert.match(workflow, /registry-url: https:\/\/registry\.npmjs\.org/)
     assert.doesNotMatch(workflow, /NPM_TOKEN|NODE_AUTH_TOKEN/)
+    assert.match(workflow, /node scripts\/publish-with-npm\.mjs/)
   })
 
   test('verifies the npm release client tarball before activating it', () => {


### PR DESCRIPTION
## Summary
- publish Changesets through `npm publish` so npm Trusted Publishing OIDC is used
- keep the pnpm workspace manifest and lockfile intact after the publish command
- retain tokenless release authentication checks

## Evidence
- `node --check scripts/publish-with-npm.mjs`
- `node --test scripts/release-workflow-auth.test.mjs`
- `pnpm check:publication-surface`
- `git diff --check`

This addresses the failed recovery runs where `pnpm changeset publish` produced signed provenance but npm rejected package authorization with E404.
