### PR TITLE
fix: make pinned npm client executable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,8 @@ jobs:
           npm_client_dir="$RUNNER_TEMP/npm-11.18.0"
           mkdir -p "$npm_client_dir"
           tar -xzf npm-11.18.0.tgz -C "$npm_client_dir" --strip-components=1
+          printf '#!/usr/bin/env bash\nexec node "%s/bin/npm-cli.js" "$@"\n' "$npm_client_dir" > "$npm_client_dir/bin/npm"
+          chmod +x "$npm_client_dir/bin/npm"
           echo "$npm_client_dir/bin" >> "$GITHUB_PATH"
           node "$npm_client_dir/bin/npm-cli.js" --version
           rm -f npm-11.18.0.tgz

--- a/scripts/release-workflow-auth.test.mjs
+++ b/scripts/release-workflow-auth.test.mjs
@@ -41,6 +41,8 @@ describe('release workflow authentication', () => {
     assert.match(workflow, /NPM_TARBALL_SHA512: [A-Za-z0-9+/]+=*/)
     assert.match(workflow, /openssl dgst -sha512 -binary npm-11\.18\.0\.tgz/)
     assert.match(workflow, /tar -xzf npm-11\.18\.0\.tgz -C "\$npm_client_dir" --strip-components=1/)
+    assert.match(workflow, /exec node "\%s\/bin\/npm-cli\.js" "\$@".*npm_client_dir/)
+    assert.match(workflow, /chmod \+x "\$npm_client_dir\/bin\/npm"/)
     assert.match(workflow, /echo "\$npm_client_dir\/bin" >> "\$GITHUB_PATH"/)
     assert.match(workflow, /node "\$npm_client_dir\/bin\/npm-cli\.js" --version/)
   })


### PR DESCRIPTION
## Summary\n- make the pinned npm tarball callable from GitHub Actions\n- keep the Changesets release path on npm for Trusted Publishing\n- cover the launcher contract in the release workflow test\n\n## Validation\n- node --test scripts/release-workflow-auth.test.mjs\n- git diff --check