### PR TITLE
fix: use pinned npm client for SBOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
           printf '#!/usr/bin/env bash\nexec node "%s/bin/npm-cli.js" "$@"\n' "$npm_client_dir" > "$npm_client_dir/bin/npm"
           chmod +x "$npm_client_dir/bin/npm"
           echo "$npm_client_dir/bin" >> "$GITHUB_PATH"
+          echo "NPM_CLIENT_DIR=$npm_client_dir" >> "$GITHUB_ENV"
           node "$npm_client_dir/bin/npm-cli.js" --version
           rm -f npm-11.18.0.tgz
       - name: Create release app token
@@ -133,7 +134,7 @@ jobs:
       - name: Generate SBOM (CycloneDX)
         if: steps.changesets.outputs.published == 'true' || steps.recovery_publish.outputs.published == 'true'
         run: |
-          npx --yes @cyclonedx/cyclonedx-npm@2.0.0 \
+          node "$NPM_CLIENT_DIR/bin/npm-cli.js" exec --yes --package="@cyclonedx/cyclonedx-npm@2.0.0" -- cyclonedx-npm \
             --output-format JSON \
             --output-file sbom.cdx.json \
             --short-PURLs \

--- a/scripts/release-workflow-auth.test.mjs
+++ b/scripts/release-workflow-auth.test.mjs
@@ -44,6 +44,15 @@ describe('release workflow authentication', () => {
     assert.match(workflow, /exec node "\%s\/bin\/npm-cli\.js" "\$@".*npm_client_dir/)
     assert.match(workflow, /chmod \+x "\$npm_client_dir\/bin\/npm"/)
     assert.match(workflow, /echo "\$npm_client_dir\/bin" >> "\$GITHUB_PATH"/)
+    assert.match(workflow, /echo "NPM_CLIENT_DIR=\$npm_client_dir" >> "\$GITHUB_ENV"/)
     assert.match(workflow, /node "\$npm_client_dir\/bin\/npm-cli\.js" --version/)
+  })
+
+  test('uses the pinned npm client for SBOM generation', () => {
+    assert.match(
+      workflow,
+      /node "\$NPM_CLIENT_DIR\/bin\/npm-cli\.js" exec --yes --package="@cyclonedx\/cyclonedx-npm@2\.0\.0" -- cyclonedx-npm/,
+    )
+    assert.doesNotMatch(workflow, /npx --yes @cyclonedx\/cyclonedx-npm/)
   })
 })


### PR DESCRIPTION
## Summary
- keep the pinned npm client available across release steps
- generate the SBOM through the pinned npm CLI instead of the incompatible npx launcher
- extend release workflow authentication coverage

## Validation
- node --test scripts/release-workflow-auth.test.mjs
- git diff --check
- npm exec --yes --package=@cyclonedx/cyclonedx-npm@2.0.0 -- cyclonedx-npm --version